### PR TITLE
feat: replace TodoList with Tag system and todo state

### DIFF
--- a/backend/alembic/versions/0003_migrate_lists_to_tags.py
+++ b/backend/alembic/versions/0003_migrate_lists_to_tags.py
@@ -1,0 +1,96 @@
+"""Migrate todo_lists to tags; add state to todos
+
+Replaces the folder-based TodoList model with a flexible Tag system
+and a GTD-friendly state field on each Todo.
+
+Revision ID: 0003
+Revises: 0002
+Create Date: 2026-04-11
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0003"
+down_revision: str | None = "0002"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # ── 1. Drop the list_id FK index and column from todos ────────────────────
+    op.drop_index("ix_todos_list_id", table_name="todos")
+    op.drop_column("todos", "list_id")
+
+    # ── 2. Drop the todo_lists table (safe — early dev, no data to preserve) ──
+    op.drop_index("ix_todo_lists_user_id", table_name="todo_lists")
+    op.drop_table("todo_lists")
+
+    # ── 3. Add state column to todos (defaults to "inbox") ────────────────────
+    op.add_column(
+        "todos",
+        sa.Column("state", sa.String(50), nullable=False, server_default="inbox"),
+    )
+
+    # ── 4. Create tags table ──────────────────────────────────────────────────
+    op.create_table(
+        "tags",
+        sa.Column("id", sa.String(), primary_key=True),
+        sa.Column("name", sa.String(100), nullable=False),
+        sa.Column("color", sa.String(20)),
+        sa.Column("user_id", sa.String(), sa.ForeignKey("users.id"), nullable=False),
+    )
+    op.create_index("ix_tags_user_id", "tags", ["user_id"])
+    op.create_unique_constraint("uq_tags_user_name", "tags", ["user_id", "name"])
+
+    # ── 5. Create todo_tags junction table ────────────────────────────────────
+    op.create_table(
+        "todo_tags",
+        sa.Column(
+            "todo_id",
+            sa.String(),
+            sa.ForeignKey("todos.id", ondelete="CASCADE"),
+            primary_key=True,
+            nullable=False,
+        ),
+        sa.Column(
+            "tag_id",
+            sa.String(),
+            sa.ForeignKey("tags.id", ondelete="CASCADE"),
+            primary_key=True,
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    # ── Reverse in opposite order ─────────────────────────────────────────────
+    op.drop_table("todo_tags")
+    op.drop_constraint("uq_tags_user_name", "tags")
+    op.drop_index("ix_tags_user_id", "tags")
+    op.drop_table("tags")
+
+    op.drop_column("todos", "state")
+
+    op.create_table(
+        "todo_lists",
+        sa.Column("id", sa.String(), primary_key=True),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("color", sa.String(20)),
+        sa.Column("icon_name", sa.String(100)),
+        sa.Column("is_archived", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime()),
+        sa.Column("user_id", sa.String(), sa.ForeignKey("users.id"), nullable=False),
+    )
+    op.create_index("ix_todo_lists_user_id", "todo_lists", ["user_id"])
+
+    op.add_column(
+        "todos",
+        sa.Column("list_id", sa.String(), sa.ForeignKey("todo_lists.id")),
+    )
+    op.create_index("ix_todos_list_id", "todos", ["list_id"])

--- a/backend/app/todos/models.py
+++ b/backend/app/todos/models.py
@@ -18,20 +18,24 @@ def _uuid() -> str:
     return str(uuid.uuid4())
 
 
-class TodoList(Base):
-    __tablename__ = "todo_lists"
+class Tag(Base):
+    __tablename__ = "tags"
 
     id: Mapped[str] = mapped_column(String, primary_key=True, default=_uuid)
-    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    name: Mapped[str] = mapped_column(String(100), nullable=False)
     color: Mapped[str | None] = mapped_column(String(20))
-    icon_name: Mapped[str | None] = mapped_column(String(100))
-    is_archived: Mapped[bool] = mapped_column(Boolean, default=False)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(UTC))
-    updated_at: Mapped[datetime | None] = mapped_column(DateTime)
-
     user_id: Mapped[str] = mapped_column(ForeignKey("users.id"), index=True, nullable=False)
 
-    todos: Mapped[list["Todo"]] = relationship("Todo", back_populates="list")
+    todos: Mapped[list["Todo"]] = relationship("Todo", secondary="todo_tags", back_populates="tags")
+
+
+class TodoTag(Base):
+    __tablename__ = "todo_tags"
+
+    todo_id: Mapped[str] = mapped_column(
+        ForeignKey("todos.id", ondelete="CASCADE"), primary_key=True
+    )
+    tag_id: Mapped[str] = mapped_column(ForeignKey("tags.id", ondelete="CASCADE"), primary_key=True)
 
 
 class Todo(Base):
@@ -46,11 +50,11 @@ class Todo(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(UTC))
     updated_at: Mapped[datetime | None] = mapped_column(DateTime)
 
-    list_id: Mapped[str | None] = mapped_column(ForeignKey("todo_lists.id"))
+    state: Mapped[str] = mapped_column(String(50), default="inbox")
     location_id: Mapped[str | None] = mapped_column(ForeignKey("locations.id"))
     user_id: Mapped[str] = mapped_column(ForeignKey("users.id"), index=True, nullable=False)
 
-    list: Mapped[TodoList | None] = relationship("TodoList", back_populates="todos")
+    tags: Mapped[list["Tag"]] = relationship("Tag", secondary="todo_tags", back_populates="todos")
     reminders: Mapped[list["Reminder"]] = relationship("Reminder", back_populates="todo")
     recurrence_rule: Mapped["RecurrenceRule | None"] = relationship(
         "RecurrenceRule", back_populates="todo", uselist=False

--- a/backend/app/todos/routes.py
+++ b/backend/app/todos/routes.py
@@ -8,14 +8,47 @@ auth-gated mutations, and operations that require server-side logic
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.auth.dependencies import get_current_user
 from app.auth.models import User
 from app.database import get_db
-from app.todos.models import Todo
+from app.todos.models import Tag, Todo
 from app.todos.schemas import TodoCreate, TodoOut, TodoUpdate
 
 router = APIRouter(prefix="/todos", tags=["todos"])
+
+
+async def _resolve_tags(
+    tag_names: list[str],
+    user_id: str,
+    db: AsyncSession,
+) -> list[Tag]:
+    """Return Tag ORM objects for the given names, creating any that don't exist yet."""
+    if not tag_names:
+        return []
+
+    result = await db.execute(select(Tag).where(Tag.user_id == user_id, Tag.name.in_(tag_names)))
+    existing = {tag.name: tag for tag in result.scalars().all()}
+
+    tags: list[Tag] = []
+    for name in tag_names:
+        if name in existing:
+            tags.append(existing[name])
+        else:
+            new_tag = Tag(name=name, user_id=user_id)
+            db.add(new_tag)
+            tags.append(new_tag)
+
+    return tags
+
+
+async def _get_todo_with_tags(todo_id: str, db: AsyncSession) -> Todo | None:
+    """Fetch a single Todo with its tags eagerly loaded."""
+    result = await db.execute(
+        select(Todo).where(Todo.id == todo_id).options(selectinload(Todo.tags))
+    )
+    return result.scalar_one_or_none()
 
 
 @router.get("/", response_model=list[TodoOut])
@@ -23,7 +56,9 @@ async def list_todos(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> list[Todo]:
-    result = await db.execute(select(Todo).where(Todo.user_id == current_user.id))
+    result = await db.execute(
+        select(Todo).where(Todo.user_id == current_user.id).options(selectinload(Todo.tags))
+    )
     return list(result.scalars().all())
 
 
@@ -33,17 +68,21 @@ async def create_todo(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> Todo:
+    tags = await _resolve_tags(body.tags, current_user.id, db)
     todo = Todo(
         title=body.title,
         notes=body.notes,
-        list_id=body.list_id,
+        state=body.state,
         priority=body.priority,
         user_id=current_user.id,
+        tags=tags,
     )
     db.add(todo)
     await db.commit()
-    await db.refresh(todo)
-    return todo
+    # Re-query to get eagerly loaded tags (refresh doesn't reload relationships)
+    loaded = await _get_todo_with_tags(todo.id, db)
+    assert loaded is not None  # just committed — must exist
+    return loaded
 
 
 @router.get("/{todo_id}", response_model=TodoOut)
@@ -52,7 +91,7 @@ async def get_todo(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> Todo:
-    todo = await db.get(Todo, todo_id)
+    todo = await _get_todo_with_tags(todo_id, db)
     if not todo or todo.user_id != current_user.id:
         raise HTTPException(status_code=404, detail="Todo not found")
     return todo
@@ -65,14 +104,23 @@ async def update_todo(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> Todo:
-    todo = await db.get(Todo, todo_id)
+    todo = await _get_todo_with_tags(todo_id, db)
     if not todo or todo.user_id != current_user.id:
         raise HTTPException(status_code=404, detail="Todo not found")
-    for field, value in body.model_dump(exclude_unset=True).items():
+
+    update_data = body.model_dump(exclude_unset=True)
+
+    # Handle tags separately — replacing the full set
+    if "tags" in update_data:
+        todo.tags = await _resolve_tags(update_data.pop("tags"), current_user.id, db)
+
+    for field, value in update_data.items():
         setattr(todo, field, value)
+
     await db.commit()
-    await db.refresh(todo)
-    return todo
+    loaded = await _get_todo_with_tags(todo.id, db)
+    assert loaded is not None  # just committed — must exist
+    return loaded
 
 
 @router.delete("/{todo_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -99,7 +147,7 @@ async def get_suggestions(
     return {"suggestions": []}
 
 
-@router.get("/lists/{list_id}/summary")
-async def summarize_list(list_id: str, _: User = Depends(get_current_user)) -> dict[str, str]:
-    # TODO: fetch todos in list, summarize
+@router.get("/tags/{tag_id}/summary")
+async def summarize_tag(tag_id: str, _: User = Depends(get_current_user)) -> dict[str, str]:
+    # TODO: fetch todos with this tag, summarize
     return {"summary": ""}

--- a/backend/app/todos/schemas.py
+++ b/backend/app/todos/schemas.py
@@ -8,7 +8,8 @@ from pydantic import BaseModel
 class TodoCreate(BaseModel):
     title: str
     notes: str | None = None
-    list_id: str | None = None
+    state: str = "inbox"
+    tags: list[str] = []  # Tag names e.g. ["@office", "Project/Renovation"]
     due_date: str | None = None
     priority: int | None = None
 
@@ -17,8 +18,18 @@ class TodoUpdate(BaseModel):
     title: str | None = None
     notes: str | None = None
     completed: bool | None = None
+    state: str | None = None
+    tags: list[str] | None = None  # Full replacement of tag set when provided
     due_date: str | None = None
     priority: int | None = None
+
+
+class TagOut(BaseModel):
+    id: str
+    name: str
+    color: str | None
+
+    model_config = {"from_attributes": True}
 
 
 class TodoOut(BaseModel):
@@ -27,7 +38,8 @@ class TodoOut(BaseModel):
     notes: str | None
     completed: bool
     priority: int | None
-    list_id: str | None
+    state: str
+    tags: list[TagOut]
     due_date: datetime | None
     created_at: datetime
 


### PR DESCRIPTION
## Summary

- **Replaces `TodoList` model** with a flexible `Tag` + `TodoTag` many-to-many system (user-owned, CASCADE deletes)
- **Adds `state` field** to `Todo` (default `"inbox"`) for GTD-style workflow
- **Updates schemas and routes**: `list_id` → `state` + `tags: list[str]`, implicit tag creation via `_resolve_tags()`, eager-loading via `selectinload`
- **Adds migration 0003** with full upgrade/downgrade support

## Test plan

- [ ] Verify migration applies cleanly on a fresh DB (`alembic upgrade head`)
- [ ] Test creating a todo with tags — tags created implicitly by name
- [ ] Test updating a todo's tags — full replacement semantics
- [ ] Test that deleting a todo cascades to `todo_tags`
- [ ] Test that deleting a tag cascades to `todo_tags`
- [ ] Verify `GET /todos/` returns tags eagerly loaded
- [ ] Test migration downgrade (`alembic downgrade 0002`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)