### PR TITLE
fix: resolve all mypy strict-mode errors

### DIFF
--- a/backend/app/auth/tokens.py
+++ b/backend/app/auth/tokens.py
@@ -5,7 +5,7 @@ import jwt
 from app.config import settings
 
 
-def create_access_token(data: dict, expires_delta: timedelta | None = None) -> str:
+def create_access_token(data: dict[str, object], expires_delta: timedelta | None = None) -> str:
     to_encode = data.copy()
     expire = datetime.now(UTC) + (
         expires_delta or timedelta(minutes=settings.access_token_expire_minutes)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -33,4 +33,4 @@ class Settings(BaseSettings):
     firebase_credentials_path: str = ""
 
 
-settings = Settings()
+settings = Settings()  # type: ignore[call-arg]  # secret_key loaded from env

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,14 +5,14 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 # Ensure all models are registered with SQLAlchemy metadata.
-import app.auth.models  # noqa: F401
-import app.todos.models  # noqa: F401
-from app.ai import routes as ai_routes
-from app.auth import routes as auth_routes
+import app.auth.models as _auth_models  # noqa: F401
+import app.todos.models as _todo_models  # noqa: F401
+from app.ai.routes import router as ai_router
+from app.auth.routes import router as auth_router
 from app.config import settings
 from app.database import engine
-from app.health import routes as health_routes
-from app.todos import routes as todo_routes
+from app.health.routes import router as health_router
+from app.todos.routes import router as todo_router
 
 
 @asynccontextmanager
@@ -37,7 +37,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-app.include_router(health_routes.router)
-app.include_router(auth_routes.router)
-app.include_router(todo_routes.router)
-app.include_router(ai_routes.router)
+app.include_router(health_router)
+app.include_router(auth_router)
+app.include_router(todo_router)
+app.include_router(ai_router)

--- a/backend/app/todos/models.py
+++ b/backend/app/todos/models.py
@@ -31,7 +31,7 @@ class TodoList(Base):
 
     user_id: Mapped[str] = mapped_column(ForeignKey("users.id"), index=True, nullable=False)
 
-    todos: Mapped[list["Todo"]] = relationship("Todo", back_populates="list")
+    todos: Mapped[list["Todo"]] = relationship("Todo", back_populates="todo_list")
 
 
 class Todo(Base):
@@ -50,7 +50,7 @@ class Todo(Base):
     location_id: Mapped[str | None] = mapped_column(ForeignKey("locations.id"))
     user_id: Mapped[str] = mapped_column(ForeignKey("users.id"), index=True, nullable=False)
 
-    list: Mapped[TodoList | None] = relationship("TodoList", back_populates="todos")
+    todo_list: Mapped[TodoList | None] = relationship("TodoList", back_populates="todos")
     reminders: Mapped[list["Reminder"]] = relationship("Reminder", back_populates="todo")
     recurrence_rule: Mapped["RecurrenceRule | None"] = relationship(
         "RecurrenceRule", back_populates="todo", uselist=False


### PR DESCRIPTION
## Summary

- **tokens.py**: add generic type args to `dict` parameter (`dict` → `dict[str, object]`)
- **config.py**: add `type: ignore[call-arg]` for `Settings()` — `secret_key` is required at runtime via env but has no default for mypy
- **main.py**: import routers directly (`from app.todos.routes import router`) instead of aliasing modules — the `import app.auth.models` statement made mypy treat `app` as a module, shadowing the `app = FastAPI()` variable
- **models.py**: rename `Todo.list` relationship to `Todo.todo_list` to avoid shadowing the builtin `list` type

Also removed stale `types-PyJWT` stubs — PyJWT 2.x ships its own `py.typed` marker.

**Result**: 13 errors → 0 errors, all 23 tests passing.

## Test plan

- [x] `mypy app/` passes with zero errors
- [x] `ruff check` and `ruff format --check` pass
- [x] Full test suite (23 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)