### PR TITLE
docs: add maintenance guidelines and current-state reminders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,3 +107,22 @@ Update after completing each goal. Keep goals small (< 30 min each).
 | `docs/` | Detailed documentation | Project-specific |
 
 Keep AGENTS.md generic. Project details go in README.md and docs/.
+
+## Documentation in docs/
+
+Files in docs/ (ARCHITECTURE.md, BACKEND_GUIDELINES.md, DESIGN.md, REQUIREMENTS.md, TESTING.md) describe the current state of the project. They are not changelogs. A reader should be able to understand the system today by reading them, without consulting git history, issues, or PRs.
+When you change code that affects anything these documents describe, update the relevant document in the same change — not at the end of the session. Treat the docs as part of the code.
+When updating:
+
+Rewrite affected sections so they describe the new state. Do not add "Updated X" or "Changed Y" notes.
+Remove statements that are no longer true. Stale claims are worse than missing ones.
+If scope, goals, or direction changed (not just implementation), update REQUIREMENTS.md or DESIGN.md accordingly.
+If you're unsure whether a doc needs updating, read the doc first and check. Don't skip this step.
+
+Git history and GitHub issues are the source of truth for how and why the system got here. The source code is the source of truth for what it is now. /docs is a summary of both.
+
+## Keep Notes
+
+When you make a non-obvious decision, encounter a surprise about this codebase, or learn something by failing an approach first, append a one-line entry to NOTES.md under today's date before moving on. Don't ask permission.
+
+

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,5 +1,7 @@
 # Architecture
 
+<!-- This document describes the current state of the system. Rewrite sections when they become inaccurate. Do not append change logs. -->
+
 This document describes the architectural design of Jeeves, a productivity-focused todos application.
 
 ## High-Level System Overview

--- a/docs/BACKEND_GUIDELINES.md
+++ b/docs/BACKEND_GUIDELINES.md
@@ -1,5 +1,7 @@
 # Backend Guidelines
 
+<!-- This document describes the current state of the system. Rewrite sections when they become inaccurate. Do not append change logs. -->
+
 This document outlines the architectural and engineering guidelines specific to the Jeeves backend service.
 
 ## 12-Factor App Methodology

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,5 +1,7 @@
 # Design System Document
 
+<!-- This document describes the current state of the system. Rewrite sections when they become inaccurate. Do not append change logs. -->
+
 This document outlines the core aesthetic and functional principles of our design system.
 
 ## Brand Identity

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -1,5 +1,7 @@
 # Product Requirements Document (PRD): GTD Execution Hybrid App
 
+<!-- This document describes the current state of the system. Rewrite sections when they become inaccurate. Do not append change logs. -->
+
 ## 1. Product Vision
 To build a hybrid productivity application that merges the rigid organizational trust of a Getting Things Done (GTD) inventory (e.g., Nirvana) with the focused, day-to-day execution layer of a daily planner and timeboxer (e.g., Sunsama). The system prioritizes immediate execution through Pomodoro constraints and maintains data integrity through forced behavioral guardrails.
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,5 +1,7 @@
 # Testing Strategy
 
+<!-- This document describes the current state of the system. Rewrite sections when they become inaccurate. Do not append change logs. -->
+
 This document outlines the testing methodology and standards for the Jeeves project.
 
 ## Development Methodology: TDD (Top-Down)


### PR DESCRIPTION
## Summary
- Add documentation maintenance and keep-notes guidelines to `AGENTS.md`
- Append current-state reminder comments to all `docs/` files (ARCHITECTURE, BACKEND_GUIDELINES, DESIGN, REQUIREMENTS, TESTING)

## Test plan
- [ ] Review rendered markdown for AGENTS.md and docs/* files
- [ ] Confirm no unrelated changes included

🤖 Generated with [Claude Code](https://claude.com/claude-code)