### PR TITLE
chore: allow wip/fixup!/squash! commits locally, block on push

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Regex to check for conventional commits (wip allowed locally, blocked on push)
-commit_regex='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert|wip)(\([a-zA-Z0-9_-]+\))?: .+'
+commit_regex='^((fixup|squash)! )?(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert|wip)(\([a-zA-Z0-9_-]+\))?: .+'
 
 if ! grep -iqE "$commit_regex" "$1"; then
     echo "❌ Error: Commit message does not follow Conventional Commits format."

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-# Regex to check for conventional commits
-commit_regex='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([a-zA-Z0-9_-]+\))?: .+'
+# Regex to check for conventional commits (wip allowed locally, blocked on push)
+commit_regex='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert|wip)(\([a-zA-Z0-9_-]+\))?: .+'
 
 if ! grep -iqE "$commit_regex" "$1"; then
     echo "❌ Error: Commit message does not follow Conventional Commits format."

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -21,7 +21,7 @@ while read -r _local_ref local_sha remote_ref remote_sha; do
             ;;
     esac
 
-    # Block pushing any wip commits
+    # Block pushing any wip/fixup!/squash! commits
     if [ "$local_sha" = "0000000000000000000000000000000000000000" ]; then
         # Branch deletion — nothing to inspect
         continue
@@ -29,15 +29,15 @@ while read -r _local_ref local_sha remote_ref remote_sha; do
 
     if [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
         # New branch — only inspect commits not already on any ref of this remote
-        wip_commits=$(git log --oneline "$local_sha" --not --remotes="$remote_name" 2>/dev/null | grep -iE '^[0-9a-f]+ wip(\(.*\))?: ')
+        wip_commits=$(git log --oneline "$local_sha" --not --remotes="$remote_name" 2>/dev/null | grep -iE '^[0-9a-f]+ (wip(\(.*\))?: |(fixup|squash)! )')
     else
-        wip_commits=$(git log --oneline "$remote_sha..$local_sha" 2>/dev/null | grep -iE '^[0-9a-f]+ wip(\(.*\))?: ')
+        wip_commits=$(git log --oneline "$remote_sha..$local_sha" 2>/dev/null | grep -iE '^[0-9a-f]+ (wip(\(.*\))?: |(fixup|squash)! )')
     fi
     if [ -n "$wip_commits" ]; then
-        echo "❌ Push rejected: found WIP commit(s):"
+        echo "❌ Push rejected: found WIP/fixup!/squash! commit(s):"
         echo "$wip_commits"
         echo ""
-        echo "Please squash or fixup WIP commits before pushing:"
+        echo "Please squash or fixup these commits before pushing:"
         echo "  git rebase -i --autosquash"
         exit 1
     fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -9,7 +9,7 @@ remote_name="$1"
 
 # Read the ref lines that git passes on stdin.
 # Each line: <local_ref> <local_sha> <remote_ref> <remote_sha>
-while read -r _local_ref _local_sha remote_ref _remote_sha; do
+while read -r _local_ref local_sha remote_ref remote_sha; do
     case "$remote_ref" in
         refs/heads/main|refs/heads/master)
             if [ "$remote_name" = "dokku" ]; then
@@ -20,6 +20,27 @@ while read -r _local_ref _local_sha remote_ref _remote_sha; do
             fi
             ;;
     esac
+
+    # Block pushing any wip commits
+    if [ "$local_sha" = "0000000000000000000000000000000000000000" ]; then
+        # Branch deletion — nothing to inspect
+        continue
+    fi
+
+    if [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
+        # New branch — only inspect commits not already on any ref of this remote
+        wip_commits=$(git log --oneline "$local_sha" --not --remotes="$remote_name" 2>/dev/null | grep -iE '^[0-9a-f]+ wip(\(.*\))?: ')
+    else
+        wip_commits=$(git log --oneline "$remote_sha..$local_sha" 2>/dev/null | grep -iE '^[0-9a-f]+ wip(\(.*\))?: ')
+    fi
+    if [ -n "$wip_commits" ]; then
+        echo "❌ Push rejected: found WIP commit(s):"
+        echo "$wip_commits"
+        echo ""
+        echo "Please squash or fixup WIP commits before pushing:"
+        echo "  git rebase -i --autosquash"
+        exit 1
+    fi
 done
 
 echo "✅ All pre-push checks passed!"


### PR DESCRIPTION
## Summary
- Allow `wip:` commit subjects locally (commit-msg regex) and reject them on push (pre-push hook).
- One-line regex extension to also permit `fixup!` / `squash!` prefixes, so `git commit --fixup` / `--autosquash` workflows stop tripping the hook.
- Pre-push hook rejects `fixup!` / `squash!` commits for the same reason `wip:` is rejected — they must be autosquashed before landing on a shared branch.

## Test plan
- [x] commit-msg regex accepts `feat:`, `wip:`, `fixup! feat:`, `squash! fix(api):`; rejects garbage.
- [x] pre-push grep matches `wip:`, `fixup! ...`, `squash! ...`; ignores plain `feat:`.
- [ ] Manual: push a branch containing a `fixup!` commit and confirm rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)