### PR TITLE
chore: upgrade Flutter deps and replace discontinued flutter_markdown

### DIFF
--- a/app/lib/screens/task_detail/task_detail_screen.dart
+++ b/app/lib/screens/task_detail/task_detail_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../../database/gtd_database.dart';

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -173,10 +173,10 @@ packages:
     dependency: "direct main"
     description:
       name: connectivity_plus
-      sha256: b5e72753cf63becce2c61fd04dfe0f1c430cc5278b53a1342dc5ad839eab29ec
+      sha256: "62ffa266d9a23b79fb3fcbc206afc00bb979417ba57b1324c546b5aab95ba057"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.5"
+    version: "7.1.1"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
@@ -347,14 +347,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
-  flutter_markdown:
+  flutter_markdown_plus:
     dependency: "direct main"
     description:
-      name: flutter_markdown
-      sha256: "08fb8315236099ff8e90cb87bb2b935e0a724a3af1623000a9cec930468e0f27"
+      name: flutter_markdown_plus
+      sha256: "039177906850278e8fb1cd364115ee0a46281135932fa8ecea8455522166d2de"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7+1"
+    version: "1.0.7"
   flutter_riverpod:
     dependency: "direct main"
     description:
@@ -367,50 +367,50 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_secure_storage
-      sha256: "9cad52d75ebc511adfae3d447d5d13da15a55a92c9410e50f67335b6d21d16ea"
+      sha256: da922f2aab2d733db7e011a6bcc4a825b844892d4edd6df83ff156b09a9b2e40
       url: "https://pub.dev"
     source: hosted
-    version: "9.2.4"
+    version: "10.0.0"
+  flutter_secure_storage_darwin:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_darwin
+      sha256: "8878c25136a79def1668c75985e8e193d9d7d095453ec28730da0315dc69aee3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   flutter_secure_storage_linux:
     dependency: transitive
     description:
       name: flutter_secure_storage_linux
-      sha256: be76c1d24a97d0b98f8b54bce6b481a380a6590df992d0098f868ad54dc8f688
+      sha256: "2b5c76dce569ab752d55a1cee6a2242bcc11fdba927078fb88c503f150767cda"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.3"
-  flutter_secure_storage_macos:
-    dependency: transitive
-    description:
-      name: flutter_secure_storage_macos
-      sha256: "6c0a2795a2d1de26ae202a0d78527d163f4acbb11cde4c75c670f3a0fc064247"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.3"
+    version: "3.0.0"
   flutter_secure_storage_platform_interface:
     dependency: transitive
     description:
       name: flutter_secure_storage_platform_interface
-      sha256: cf91ad32ce5adef6fba4d736a542baca9daf3beac4db2d04be350b87f69ac4a8
+      sha256: "8ceea1223bee3c6ac1a22dabd8feefc550e4729b3675de4b5900f55afcb435d6"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "2.0.1"
   flutter_secure_storage_web:
     dependency: transitive
     description:
       name: flutter_secure_storage_web
-      sha256: f4ebff989b4f07b2656fb16b47852c0aab9fed9b4ec1c70103368337bc1886a9
+      sha256: "6a1137df62b84b54261dca582c1c09ea72f4f9a4b2fcee21b025964132d5d0c3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "2.1.0"
   flutter_secure_storage_windows:
     dependency: transitive
     description:
       name: flutter_secure_storage_windows
-      sha256: b20b07cb5ed4ed74fc567b78a72936203f587eba460af1df11281c9326cd3709
+      sha256: "3b7c8e068875dfd46719ff57c90d8c459c87f2302ed6b00ff006b3c9fcad1613"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "4.1.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -558,18 +558,18 @@ packages:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: f02fd7d2a4dc512fec615529824fdd217fecb3a3d3de68360293a551f21634b3
+      sha256: "5540e4a3f416dd4a93458257b908eb88353cbd0fb5b0a3d1bd7d849ba1e88735"
       url: "https://pub.dev"
     source: hosted
-    version: "14.8.1"
+    version: "17.2.1"
   google_fonts:
     dependency: "direct main"
     description:
       name: google_fonts
-      sha256: ba03d03bcaa2f6cb7bd920e3b5027181db75ab524f8891c8bc3aa603885b8055
+      sha256: db9df7a5898d894eeda4c78143f35c30a243558be439518972366880b80bf88e
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.3"
+    version: "8.0.2"
   graphs:
     dependency: transitive
     description:
@@ -655,14 +655,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.7"
   json_annotation:
     dependency: "direct main"
     description:
@@ -1416,10 +1408,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60"
+      sha256: "046d3928e16fa4dc46e8350415661755ab759d9fc97fc21b5ab295f71e4f0499"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.2"
+    version: "15.1.0"
   watcher:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -34,6 +34,10 @@ dependencies:
   retrofit: ^4.9.2
 
   # Sync (PowerSync — bidirectional offline-first sync)
+  # Held at 1.x: powersync 2.0 requires sqlite3 ^3.2.0 → drift_dev 2.32+
+  # → analyzer ^10, which conflicts with riverpod_generator 4.0.3
+  # (latest, pinned to analyzer ^9). Revisit when riverpod_generator
+  # releases an analyzer-10-compatible version.
   powersync: ^1.0.0
 
   # Notifications
@@ -52,24 +56,24 @@ dependencies:
   # (calls backend AI endpoint via api_service)
 
   # Navigation
-  go_router: ^14.0.0
+  go_router: ^17.2.1
 
   # Connectivity
-  connectivity_plus: ^6.1.1
+  connectivity_plus: ^7.1.1
 
   # Local key-value persistence (planning ritual state)
   shared_preferences: ^2.3.3
 
   # Encrypted token storage (JWT)
-  flutter_secure_storage: ^9.0.0
+  flutter_secure_storage: ^10.0.0
 
   # Utilities
   uuid: ^4.4.0
   freezed_annotation: ^3.1.0
   json_annotation: ^4.11.0
   intl: ^0.20.2
-  google_fonts: ^6.2.1
-  flutter_markdown: ^0.7.1
+  google_fonts: ^8.0.2
+  flutter_markdown_plus: ^1.0.7
   url_launcher: ^6.3.0
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
Older packages are a maintenance and security liability. Bumps every dep that resolves cleanly under the current `analyzer 9` / `riverpod_generator 4.0.3` constraints, plus swaps the now-discontinued `flutter_markdown` for its successor.

- `go_router`             14.x  → **17.2.1**
- `flutter_secure_storage` 9.x  → **10.0.0**
- `connectivity_plus`      6.x  → **7.1.1**
- `google_fonts`           6.x  → **8.0.2**
- `flutter_markdown` (discontinued) → **`flutter_markdown_plus` 1.0.7**
- `vm_service`             15.0.2 → 15.1.0 (transitive)

`flutter analyze` is clean and all 149 unit/widget tests pass with no source changes beyond the markdown import swap (`task_detail_screen.dart`).

## Held back: powersync 1.18 → 2.0
Intentionally not bumped. PowerSync 2.0 requires `sqlite3 ^3.2.0`, which forces `drift_dev 2.32+` → `analyzer ^10`, which conflicts with `riverpod_generator 4.0.3` (latest, pinned to `analyzer ^9`). Documented inline in `pubspec.yaml` so we revisit when `riverpod_generator` ships an analyzer-10-compatible release. The remaining "25 packages have newer versions incompatible" warning is essentially this single transitive cluster.

## Test plan
- [x] `flutter analyze` — no issues
- [x] `flutter test` — 149/149 passed
- [ ] Manual smoke on the markdown-rendered notes view in `TaskDetailScreen` (verifies `flutter_markdown_plus` is API-compatible at runtime)
- [ ] Manual smoke on navigation (`go_router` 14 → 17 is a 3-major jump)
- [ ] Manual smoke on login/logout (`flutter_secure_storage` 9 → 10 changed platform packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)