### PR TITLE
fix(backend-cd): use full clone to avoid shallow push rejection

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Check for backend changes
         id: backend-changes


### PR DESCRIPTION
## Summary
- Backend CD has been failing since PR #105 reduced `fetch-depth` to 2 — Dokku rejects shallow pushes with `remote rejected HEAD -> main (shallow update not allowed)`, even though the deploy itself runs successfully on the remote.
- Revert to `fetch-depth: 0` so the push contains full history. The diff-based `backend/` change check still works fine.

## Test plan
- [ ] Merge and confirm the next Backend CD run on `main` succeeds end-to-end (no `shallow update not allowed` error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)