### PR TITLE
fix(sync): accept Drift's local-tz due_date format; normalise client writes to UTC

### DIFF
--- a/app/lib/database/daos/todo_dao.dart
+++ b/app/lib/database/daos/todo_dao.dart
@@ -424,7 +424,11 @@ class TodoDao extends DatabaseAccessor<GtdDatabase> with _$TodoDaoMixin {
     await (update(todos)
           ..where((t) => t.id.equals(id) & t.userId.equals(userId)))
         .write(TodosCompanion(
-      dueDate: Value(newDueDate),
+      // Store UTC so Drift's storeDateTimeAsText path emits a standard
+      // ISO-8601 string (no leading-space offset).  Otherwise PowerSync
+      // uploads "...000 +05:30" which asyncpg's TIMESTAMPTZ encoder
+      // rejects, poisoning the CRUD queue.
+      dueDate: Value(newDueDate.toUtc()),
       updatedAt: Value(ts),
     ));
   }
@@ -517,10 +521,11 @@ class TodoDao extends DatabaseAccessor<GtdDatabase> with _$TodoDaoMixin {
       energyLevel: energyLevel != null ? Value(energyLevel) : const Value.absent(),
       timeEstimate: timeEstimate != null ? Value(timeEstimate) : const Value.absent(),
       state: newState != null ? Value(newState) : const Value.absent(),
+      // Normalise to UTC; see rescheduleTask for rationale.
       dueDate: clearDueDate
           ? const Value(null)
           : dueDate != null
-              ? Value(dueDate)
+              ? Value(dueDate.toUtc())
               : const Value.absent(),
       blockedByTodoId: clearBlockedBy
           ? const Value(null)

--- a/app/lib/database/daos/todo_dao.dart
+++ b/app/lib/database/daos/todo_dao.dart
@@ -340,7 +340,11 @@ class TodoDao extends DatabaseAccessor<GtdDatabase> with _$TodoDaoMixin {
         .where((t) =>
             t.state == GtdState.scheduled.value &&
             t.dueDate != null &&
-            _fmtDate(t.dueDate!) == today &&
+            // Storage is UTC (see TodoDao.rescheduleTask / updateFields) but
+            // [today] is a *local* calendar day from planningToday().  Convert
+            // back before formatting so the comparison is local-day vs
+            // local-day; otherwise non-UTC devices drop tasks a day early.
+            _fmtDate(t.dueDate!.toLocal()) == today &&
             (t.dailySelectionDate == null || t.dailySelectionDate != today))
         .toList());
   }

--- a/app/lib/screens/focus_screen.dart
+++ b/app/lib/screens/focus_screen.dart
@@ -178,13 +178,17 @@ class _TaskRow extends ConsumerWidget {
                     ),
                     if (todo.dueDate != null) ...[
                       const SizedBox(height: 2),
-                      Text(
-                        'Due ${todo.dueDate!.year}-'
-                        '${todo.dueDate!.month.toString().padLeft(2, '0')}-'
-                        '${todo.dueDate!.day.toString().padLeft(2, '0')}',
-                        style: const TextStyle(
-                            fontSize: 12, color: Color(0xFF9CA3AF)),
-                      ),
+                      Builder(builder: (_) {
+                        // Storage is UTC; display the user's local calendar day.
+                        final d = todo.dueDate!.toLocal();
+                        return Text(
+                          'Due ${d.year}-'
+                          '${d.month.toString().padLeft(2, '0')}-'
+                          '${d.day.toString().padLeft(2, '0')}',
+                          style: const TextStyle(
+                              fontSize: 12, color: Color(0xFF9CA3AF)),
+                        );
+                      }),
                     ],
                     if (estimate != null) ...[
                       const SizedBox(height: 2),

--- a/app/lib/screens/planning/steps/inbox_clarification_step.dart
+++ b/app/lib/screens/planning/steps/inbox_clarification_step.dart
@@ -87,7 +87,9 @@ class _ClarifyCardState extends ConsumerState<_ClarifyCard> {
     _notesCtrl = TextEditingController(text: widget.todo.notes ?? '');
     _energyLevel = widget.todo.energyLevel;
     _timeEstimate = widget.todo.timeEstimate;
-    _dueDate = widget.todo.dueDate;
+    // Storage is UTC; the picker and the year/month/day display below need
+    // local-tz semantics so the user sees the calendar day they chose.
+    _dueDate = widget.todo.dueDate?.toLocal();
   }
 
   @override

--- a/app/lib/screens/planning/steps/scheduled_review_step.dart
+++ b/app/lib/screens/planning/steps/scheduled_review_step.dart
@@ -138,12 +138,16 @@ class _TaskRow extends StatelessWidget {
                       fontSize: 15, color: Color(0xFF1A1A2E), fontWeight: FontWeight.w500),
                 ),
                 if (todo.dueDate != null)
-                  Text(
-                    'Due ${todo.dueDate!.year}-'
-                    '${todo.dueDate!.month.toString().padLeft(2, '0')}-'
-                    '${todo.dueDate!.day.toString().padLeft(2, '0')}',
-                    style: TextStyle(fontSize: 12, color: Colors.grey[500]),
-                  ),
+                  Builder(builder: (_) {
+                    // Storage is UTC; display the user's local calendar day.
+                    final d = todo.dueDate!.toLocal();
+                    return Text(
+                      'Due ${d.year}-'
+                      '${d.month.toString().padLeft(2, '0')}-'
+                      '${d.day.toString().padLeft(2, '0')}',
+                      style: TextStyle(fontSize: 12, color: Colors.grey[500]),
+                    );
+                  }),
               ],
             ),
           ),

--- a/app/lib/screens/task_detail/task_detail_screen.dart
+++ b/app/lib/screens/task_detail/task_detail_screen.dart
@@ -379,7 +379,10 @@ class _TaskDetailScreenState extends ConsumerState<TaskDetailScreen> {
                                       onTap: () async {
                                         final picked = await showDatePicker(
                                           context: context,
-                                          initialDate: todo.dueDate ?? DateTime.now(),
+                                          // Storage is UTC; DatePicker reads
+                                          // year/month/day verbatim, so feed
+                                          // the local-tz instant.
+                                          initialDate: todo.dueDate?.toLocal() ?? DateTime.now(),
                                           firstDate: DateTime(2000),
                                           lastDate: DateTime(2100),
                                           builder: (ctx, child) => Theme(

--- a/app/test/database/planning_dao_test.dart
+++ b/app/test/database/planning_dao_test.dart
@@ -338,6 +338,23 @@ void main() {
           await db.todoDao.watchScheduledDueToday(_userId, _today).first;
       expect(items, isEmpty);
     });
+
+    test('rescheduled task (UTC-normalised write) appears on its local day',
+        () async {
+      // Regression: rescheduleTask stores UTC to keep asyncpg happy, so the
+      // row is read back as UTC.  watchScheduledDueToday must convert back to
+      // local before formatting or non-UTC devices miss the task.
+      await _insert(db, id: 'a', title: 'A', state: 'scheduled');
+      // Local midnight on the session's "today" — the instant a user picks
+      // when they reschedule a task to today's date.
+      final localToday = DateTime(2026, 4, 16);
+      await db.todoDao.rescheduleTask('a', _userId, localToday);
+
+      final items =
+          await db.todoDao.watchScheduledDueToday(_userId, _today).first;
+      expect(items.length, 1);
+      expect(items.first.id, 'a');
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/app/test/database/planning_dao_test.dart
+++ b/app/test/database/planning_dao_test.dart
@@ -344,11 +344,28 @@ void main() {
       // Regression: rescheduleTask stores UTC to keep asyncpg happy, so the
       // row is read back as UTC.  watchScheduledDueToday must convert back to
       // local before formatting or non-UTC devices miss the task.
+      //
+      // The bug only manifests when the UTC-day of the chosen local moment
+      // differs from its local-day (e.g. IST +5:30, where local midnight is
+      // the previous UTC day).  In UTC and in negative-offset zones the two
+      // agree, so both the pre-fix and post-fix code paths return the same
+      // answer and the regression cannot be observed.  Skip in that case
+      // rather than silently pass — run under `TZ=Asia/Kolkata` (or any
+      // positive-offset zone) to exercise this.
+      final localMidnight = DateTime(2026, 4, 16);
+      final utcMidnight = localMidnight.toUtc();
+      if (localMidnight.year == utcMidnight.year &&
+          localMidnight.month == utcMidnight.month &&
+          localMidnight.day == utcMidnight.day) {
+        markTestSkipped(
+            'Host TZ does not exercise the UTC-vs-local-day mismatch; '
+            'run with TZ=Asia/Kolkata (or any positive-offset zone).');
+        return;
+      }
       await _insert(db, id: 'a', title: 'A', state: 'scheduled');
       // Local midnight on the session's "today" — the instant a user picks
       // when they reschedule a task to today's date.
-      final localToday = DateTime(2026, 4, 16);
-      await db.todoDao.rescheduleTask('a', _userId, localToday);
+      await db.todoDao.rescheduleTask('a', _userId, localMidnight);
 
       final items =
           await db.todoDao.watchScheduledDueToday(_userId, _today).first;

--- a/app/test/database/planning_dao_test.dart
+++ b/app/test/database/planning_dao_test.dart
@@ -319,7 +319,9 @@ void main() {
 
       final row = await db.todoDao.getTodo('a', _userId);
       expect(row?.state, GtdState.scheduled.value);
-      expect(row?.dueDate, newDate);
+      // rescheduleTask normalises to UTC so Drift emits a standard ISO-8601
+      // offset that asyncpg's TIMESTAMPTZ encoder can parse.
+      expect(row?.dueDate, newDate.toUtc());
     });
 
     test('rescheduled task disappears from watchScheduledDueToday', () async {

--- a/backend/app/import_nirvana/converter.py
+++ b/backend/app/import_nirvana/converter.py
@@ -1,5 +1,7 @@
 """Convert NirvanaItem list → project tag names + TodoCreate list."""
 
+from datetime import datetime
+
 from app.import_nirvana.schemas import NirvanaItem
 from app.todos.schemas import TagInput, TodoCreate
 
@@ -60,7 +62,10 @@ def convert_items(
                 completed=item.completed,
                 state=item.state,
                 tags=tag_specs,
-                due_date=item.due_date,
+                # NirvanaItem.due_date is the raw ISO string from the export;
+                # TodoCreate's validator parses it.  Pre-convert so mypy sees
+                # the datetime type the schema now declares.
+                due_date=datetime.fromisoformat(item.due_date) if item.due_date else None,
                 time_estimate=item.time_estimate,
                 energy_level=item.energy_level,
                 waiting_for=item.waiting_for,

--- a/backend/app/import_nirvana/routes.py
+++ b/backend/app/import_nirvana/routes.py
@@ -1,7 +1,5 @@
 """Import endpoint: POST /import/nirvana."""
 
-from datetime import datetime
-
 from fastapi import APIRouter, Depends, Form, HTTPException, UploadFile, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -112,14 +110,13 @@ async def import_nirvana(
         pending: list[tuple[Todo, list[Tag]]] = []
         for payload in batch:
             tags = await resolve_tags(payload.tags, current_user.id, db)
-            due_date = datetime.fromisoformat(payload.due_date) if payload.due_date else None
             todo = Todo(
                 title=payload.title,
                 notes=payload.notes,
                 state=payload.state,
                 completed=payload.completed,
                 priority=payload.priority,
-                due_date=due_date,
+                due_date=payload.due_date,
                 time_estimate=payload.time_estimate,
                 energy_level=payload.energy_level,
                 waiting_for=payload.waiting_for,

--- a/backend/app/todos/routes.py
+++ b/backend/app/todos/routes.py
@@ -5,8 +5,6 @@ auth-gated mutations, and operations that require server-side logic
 (e.g. recurrence expansion, AI-assisted parsing).
 """
 
-from datetime import datetime
-
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -63,7 +61,6 @@ async def create_todo(
     current_user: User = Depends(get_current_user),
 ) -> Todo:
     tags = await resolve_tags(body.tags, current_user.id, db)
-    due_date = datetime.fromisoformat(body.due_date) if body.due_date else None
     # Check for existing todo by client-provided id (idempotent retry support).
     if body.id is not None:
         existing = await _get_todo_with_tags(body.id, db)
@@ -76,7 +73,7 @@ async def create_todo(
         completed=body.completed,
         state=body.state,
         priority=body.priority,
-        due_date=due_date,
+        due_date=body.due_date,
         time_estimate=body.time_estimate,
         energy_level=body.energy_level,
         capture_source=body.capture_source,

--- a/backend/app/todos/schemas.py
+++ b/backend/app/todos/schemas.py
@@ -8,6 +8,21 @@ from pydantic import BaseModel, Field, field_validator
 from app.todos.models import ENERGY_LEVELS, GTD_STATES, TAG_TYPES
 
 
+def _normalise_drift_iso(value: object) -> object:
+    """Strip the leading space Drift inserts before the timezone offset.
+
+    When `storeDateTimeAsText` is enabled, Drift serialises non-UTC
+    DateTimes as ``2026-04-30T00:00:00.000 +05:30`` — note the space.  That
+    format is accepted by SQLite's date functions but rejected by Pydantic's
+    ISO-8601 parser (and asyncpg's TIMESTAMPTZ encoder).  Removing the space
+    yields a standard offset that Pydantic parses natively, while leaving
+    already-clean strings (``…Z``, ``…+00:00``) untouched.
+    """
+    if isinstance(value, str):
+        return value.replace(" +", "+").replace(" -", "-")
+    return value
+
+
 class TagType(StrEnum):
     context = "context"
     project = "project"
@@ -71,7 +86,7 @@ class TodoCreate(BaseModel):
     # Each item is either a plain string ("@office") or a TagInput dict.
     # Plain strings: "@" prefix → context; bare word → label.
     tags: list[str | TagInput] = []
-    due_date: str | None = None
+    due_date: datetime | None = None
     priority: int | None = None
     time_estimate: int | None = None  # minutes
     energy_level: str | None = None  # 'low' | 'medium' | 'high'
@@ -83,6 +98,8 @@ class TodoCreate(BaseModel):
     blocked_by_todo_id: str | None = None
     selected_for_today: bool | None = None
     daily_selection_date: str | None = None
+
+    _normalise_due_date = field_validator("due_date", mode="before")(_normalise_drift_iso)
 
     @field_validator("state")
     @classmethod
@@ -105,7 +122,7 @@ class TodoUpdate(BaseModel):
     completed: bool | None = None
     state: str | None = None
     tags: list[str | TagInput] | None = None  # Full replacement of tag set when provided
-    due_date: str | None = None
+    due_date: datetime | None = None
     priority: int | None = None
     time_estimate: int | None = None
     energy_level: str | None = None
@@ -117,6 +134,8 @@ class TodoUpdate(BaseModel):
     blocked_by_todo_id: str | None = None
     selected_for_today: bool | None = None
     daily_selection_date: str | None = None
+
+    _normalise_due_date = field_validator("due_date", mode="before")(_normalise_drift_iso)
 
     @field_validator("state")
     @classmethod

--- a/backend/tests/test_e2e.py
+++ b/backend/tests/test_e2e.py
@@ -1,5 +1,7 @@
 """End-to-end tests covering complete user journeys."""
 
+from datetime import datetime
+
 import pytest
 from httpx import AsyncClient
 
@@ -241,3 +243,33 @@ async def test_capture_source_tracking(client: AsyncClient) -> None:
     listed_sources = {t["id"]: t["capture_source"] for t in listing.json()}
     for todo_id, source in zip(created_ids, sources, strict=False):
         assert listed_sources[todo_id] == source
+
+
+@pytest.mark.asyncio
+async def test_due_date_accepts_drift_local_tz_format(client: AsyncClient) -> None:
+    """PowerSync uploads due_date in Drift's local-tz format with a space
+    before the offset (e.g. '2026-04-30T00:00:00.000 +05:30').  That format
+    is non-standard ISO 8601 but is what Drift produces when
+    `storeDateTimeAsText` is enabled and the DateTime is local.  We must
+    accept it — otherwise PowerSync's CRUD queue gets stuck retrying a
+    poisoned PATCH and the sync indicator goes red."""
+    reg = await client.post("/user", json={"email": "due-date@example.com", "password": "s3cret"})
+    headers = auth_header(reg.json()["access_token"])
+
+    create = await client.post("/todos/", json={"title": "Reschedule me"}, headers=headers)
+    todo_id = create.json()["id"]
+
+    drift_format = "2026-04-30T00:00:00.000 +05:30"
+    expected_instant = datetime.fromisoformat("2026-04-30T00:00:00+05:30")
+    patch = await client.patch(
+        f"/todos/{todo_id}", json={"due_date": drift_format}, headers=headers
+    )
+    assert patch.status_code == 200, patch.text
+    assert datetime.fromisoformat(patch.json()["due_date"]) == expected_instant
+
+    # POST should also accept it.
+    posted = await client.post(
+        "/todos/", json={"title": "Plan now", "due_date": drift_format}, headers=headers
+    )
+    assert posted.status_code == 201, posted.text
+    assert datetime.fromisoformat(posted.json()["due_date"]) == expected_instant


### PR DESCRIPTION
## Summary

PowerSync uploads from the Flutter client were getting stuck retrying a poisoned PATCH whenever a todo had a `due_date` set on a non-UTC device, turning the sync indicator red.

Two-part root cause:

1. **Backend schema mistype.** `TodoCreate.due_date` / `TodoUpdate.due_date` were typed as `str | None`, so the raw string flowed through to asyncpg's `TIMESTAMPTZ` encoder, which rejected Drift's local-tz serialisation `'2026-04-30T00:00:00.000 +05:30'` — note the leading space before the offset, which is non-standard ISO 8601 but what Drift emits when `storeDateTimeAsText: true` and the `DateTime` is local. asyncpg returned 500, the connector classified 500 as transient, and the CRUD queue retried forever.
2. **Client serialised local-tz `DateTime`s verbatim**, hitting the space-prefixed branch of Drift's serialiser (`drift/lib/src/runtime/types/mapping.dart:65-69`).

## Changes

**Backend (`backend/app/todos/schemas.py`, `routes.py`, `import_nirvana/{converter,routes}.py`)**
- Change `TodoCreate.due_date` / `TodoUpdate.due_date` from `str | None` to `datetime | None`.
- Add `_normalise_drift_iso` `field_validator(mode='before')` that strips the leading space so Pydantic's ISO parser accepts the value.
- Drop the now-redundant `datetime.fromisoformat(body.due_date)` calls in `create_todo` and the Nirvana import route.
- Pre-convert at the Nirvana converter call site (`NirvanaItem.due_date` is still a string from the export parser).

**Client (`app/lib/database/daos/todo_dao.dart`)**
- Normalise `dueDate` to UTC at write sites (`rescheduleTask`, `updateFields`). When the `DateTime` is UTC, Drift takes the early `toIso8601String()` path and emits a standard offset, sidestepping the space-prefix entirely.

**Tests**
- New backend regression test `test_due_date_accepts_drift_local_tz_format` covering both `POST /todos/` and `PATCH /todos/{id}` with the Drift format.
- Update `planning_dao_test.dart` expectation to match the new UTC normalisation in `rescheduleTask`.

## Test plan

- [x] `uv --project backend run pytest` — 93 passed
- [x] `flutter test` (in `app/`) — 244 passed
- [x] `uv --project backend run mypy backend/app/` — clean
- [x] `uv --project backend run ruff check / format --check` — clean
- [ ] Manual: create todo with due date on non-UTC device, observe sync indicator stays green and asyncpg accepts the upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)