### PR TITLE
chore(backend): add .dockerignore to shrink build context

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,30 @@
+# Python
+.venv/
+**/__pycache__/
+*.pyc
+*.pyo
+*.pyd
+
+# Tooling caches
+.mypy_cache/
+.pytest_cache/
+.ruff_cache/
+
+# Tests are not run inside the runtime image
+tests/
+
+# Local env files (keep the example for reference)
+.env
+.env.*
+!.env.example
+
+# VCS / build metadata
+.git/
+.gitignore
+Dockerfile
+.dockerignore
+
+# Editor / OS cruft
+.vscode/
+.idea/
+.DS_Store


### PR DESCRIPTION
## Summary
- Backend image build context was ~208 MB uncompressed (~54 MB gzipped) because nothing was excluded — the entire host `.venv/` (191 MB) plus `.mypy_cache/`, `.pytest_cache/`, `.ruff_cache/` were being shipped to the builder and then baked into the image via `COPY . .` in `backend/Dockerfile`.
- Add `backend/.dockerignore` excluding virtualenvs, tooling caches, tests, local `.env*` (keeping `.env.example`), and VCS metadata.
- Effective context drops from ~208 MB → **~0.44 MB** (~470× smaller). Resulting image is also smaller since stale host caches no longer get copied in.

## Test plan
- [x] `tar` simulation of effective context after ignores: 0.44 MB
- [x] Pre-commit hooks (ruff / mypy / pytest 65 passed) green
- [ ] Verify a fresh `podman compose build backend` succeeds and runs migrations + uvicorn as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)