### PR TITLE
chore: move direnv .envrc to project root

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,5 @@
+# Adds the FVM-managed Flutter SDK to PATH so plain `flutter` / `dart`
+# resolve to the version pinned in app/.fvmrc — including from the
+# project root, where the Makefile invokes `flutter` directly.
+# Outside the project, direnv unloads this and your shell has no flutter.
+PATH_add app/.fvm/flutter_sdk/bin

--- a/app/.envrc
+++ b/app/.envrc
@@ -1,4 +1,0 @@
-# Adds the FVM-managed Flutter SDK to PATH so plain `flutter` / `dart`
-# inside this directory resolve to the version pinned in .fvmrc.
-# Outside the project, direnv unloads this and your shell has no flutter.
-PATH_add .fvm/flutter_sdk/bin


### PR DESCRIPTION
## Summary
- Move `.envrc` from `app/` to the project root so `PATH_add app/.fvm/flutter_sdk/bin` is active from anywhere in the repo.
- Fixes `make setup` / `make emulator-android` etc. failing with `flutter: command not found` because `Makefile:27` and `Makefile:81` invoke `flutter` from the project root before any `cd app`.
- Git hooks under `.githooks/` are unaffected — they already do their own PATH resolution.

## Test plan
- [ ] `direnv allow` at the project root
- [ ] `which flutter` from the project root resolves to `app/.fvm/flutter_sdk/bin/flutter`
- [ ] `make setup` completes without `command not found`

🤖 Generated with [Claude Code](https://claude.com/claude-code)