### PR TITLE
fix(android): revert AGP 9 and migrate Kotlin jvmTarget DSL

### DIFF
--- a/app/android/app/build.gradle.kts
+++ b/app/android/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     id("com.android.application")
     id("kotlin-android")
@@ -14,10 +16,6 @@ android {
         isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
     }
 
     defaultConfig {
@@ -49,6 +47,12 @@ android {
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig = signingConfigs.getByName("debug")
         }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_17
     }
 }
 

--- a/app/android/settings.gradle.kts
+++ b/app/android/settings.gradle.kts
@@ -19,7 +19,7 @@ pluginManagement {
 
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-    id("com.android.application") version "9.2.0" apply false
+    id("com.android.application") version "8.11.1" apply false
     id("org.jetbrains.kotlin.android") version "2.3.21" apply false
 }
 


### PR DESCRIPTION
## Summary

Main is broken after merging dependabot #170 and #172. Two issues:

1. **Kotlin 2.3.21 (#170)** made `kotlinOptions { jvmTarget: String }` a hard error. The release APK build (`App CD`) fails at `app/android/app/build.gradle.kts:20`.
2. **AGP 9.2.0 (#172)** is not compatible with Flutter 3.41.6 (pinned in `app/.fvmrc`) — the Flutter Gradle plugin trips an NPE under AGP 9's `android.newDsl` contract, and AGP 9 also drops the separate `kotlin-android` plugin.

This PR:
- **Reverts AGP** back to `8.11.1` (effective revert of #172). Upgrading Flutter is a separate, larger conversation.
- **Migrates the Kotlin DSL** to the new `kotlin { compilerOptions { jvmTarget = JvmTarget.JVM_17 } }` block so Kotlin 2.3 (#170) keeps working.

Verified locally with `flutter build apk --debug --flavor production` against the FVM-pinned 3.41.6 toolchain — build succeeds.

## Test plan
- [ ] Flutter CI passes (`flutter analyze` + `flutter test`)
- [ ] `App CD` succeeds on merge (full APK release build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)