### PR TITLE
fix(infra): mount postgres volume at /var/lib/postgresql for PG18 layout

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
     # PowerSync requires logical replication
     command: >
       postgres


### PR DESCRIPTION
## Summary
- PG18 moved its on-disk layout to `/var/lib/postgresql/<major>/docker/` and refuses to start when it finds a PG≤17 layout at `/var/lib/postgresql/data`. Move the volume mount up one level so the image manages the version-specific subdirectory itself.
- Aligns with the upstream recommendation in docker-library/postgres#37 / #1259 — a single parent mount keeps `pg_upgrade --link` working across future majors without crossing mount boundaries.
- Follow-up to #163 (PG 16 → 18 bump), which is what surfaced the error.

## Migration note
Existing local `postgres_data` volumes still hold PG≤17 layout and will fail to start after this change. For the dev stack, wipe and reseed:

```
podman compose -f infra/docker-compose.yml down
podman volume rm infra_postgres_data
podman compose -f infra/docker-compose.yml up -d postgres
```

The backend service re-runs `alembic upgrade head` on startup, so the schema comes back automatically. If any contributor has local dev data worth keeping, `pg_dumpall` from a transient PG17 container against the old volume, then restore into the fresh PG18 volume.

## Test plan
- [ ] `podman volume rm infra_postgres_data` then `podman compose -f infra/docker-compose.yml up -d postgres` — container reaches healthy state.
- [ ] `podman compose -f infra/docker-compose.yml up -d` — backend starts, migrations apply, PowerSync connects.
- [ ] `podman exec <postgres> psql -U jeeves -d jeeves -c '\l'` — database exists and is reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)