### PR TITLE
auth: use back arrow instead of X on login and register

### DIFF
--- a/app/lib/screens/auth/login_screen.dart
+++ b/app/lib/screens/auth/login_screen.dart
@@ -100,7 +100,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
           ? AppBar(
               backgroundColor: Colors.white,
               elevation: 0,
-              leading: CloseButton(onPressed: () => context.pop()),
+              leading: BackButton(onPressed: () => context.pop()),
             )
           : null,
       body: SafeArea(

--- a/app/lib/screens/auth/register_screen.dart
+++ b/app/lib/screens/auth/register_screen.dart
@@ -70,7 +70,7 @@ class _RegisterScreenState extends ConsumerState<RegisterScreen> {
           ? AppBar(
               backgroundColor: Colors.white,
               elevation: 0,
-              leading: CloseButton(onPressed: () => context.pop()),
+              leading: BackButton(onPressed: () => context.pop()),
             )
           : null,
       body: SafeArea(


### PR DESCRIPTION
## Summary
- Settings uses a left-arrow `BackButton`; login and register were using `CloseButton` (X). Swap both to `BackButton` so all top-of-stack nav screens share one affordance.
- `onPressed: context.pop()` behavior is unchanged — only the glyph changes.

## Test plan
- [ ] From `/inbox` → drawer → Settings → "Sign in to sync across devices"; top-left shows `←`, not `X`, and tapping it returns to Settings.
- [ ] From login tap "Create one" → Register screen; top-left shows `←`, and tapping it pops back to login.
- [ ] Deep-linking directly to `/login` or `/register` (no nav stack) still shows no app bar (unchanged `canPop` gating).

🤖 Generated with [Claude Code](https://claude.com/claude-code)