### PR TITLE
docs(task-model): lock rollout decisions and add rollout plan

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,5 +1,9 @@
 # Notes
 
+## 2026-04-26
+
+- Task-model rollout decisions locked (see `docs/proposals/task-model-rollout.md`): #185 ships as 11 sequential vertical-slice PRs (A–K), state column shrinks one allowed value per PR, FocusSession lands in a single load-bearing PR I (no FSM↔FocusSession coexistence). Polymorphic blockers (#181) explicitly NOT a prerequisite — `scheduled`/`blocked`/`waiting_for` strip first and lose `blocked_by_todo_id` (lossy, alpha-acceptable). TimeLog (#182, PR D) ships without `focus_session_id` (added in PR I). Pomodoro sprints stop writing time directly. `completed_at` renamed to `done_at` (not parallel-added). `intent` enum 3-value at column level day one (`{next, maybe, trash}`); UI surfaces next+maybe only. PR I scope is "wire don't rewrite" — new ritual UX (#180) is out of scope. Decisions mirrored into proposal §4.5/§6/§7.1/§7.2/§8/§9.1.
+
 ## 2026-04-26 (issue #183)
 
 - Issue-author comments override review-bot scope interpretations when the two conflict on the same point. CodeRabbit flagged the `planning_settings_*` → `focus_session_planning_settings_*` prefs migration as a "no backwards-compatibility shims" scope violation, but the issue author had explicitly authorized that exact migration in the #183 comment thread — a comment the bot cannot read. Capitulating to the bot's reading erased a sanctioned migration and shipped a silent settings-loss regression (planning time, notification/banner toggles, snooze duration silently reset to defaults on upgrade). Future: re-read the full comment thread on the referenced issue before treating a CI reviewer's scope objection as authoritative.

--- a/docs/proposals/task-model-rollout.md
+++ b/docs/proposals/task-model-rollout.md
@@ -1,0 +1,479 @@
+# Task model rollout — decompose TMaYaD/Jeeves#185 into reviewable PRs
+
+> **Status:** rollout plan for the proposal in
+> `docs/proposals/task-model.md`. Companion document: read the proposal for
+> *what* the new model is and *why*; read this document for *how* it lands
+> in the repo, in what order, and with what per-PR scope.
+>
+> **Date:** 2026-04-26.
+> **Tracking issue:** TMaYaD/Jeeves#185 (parent / load-bearing).
+
+## Context
+
+`docs/proposals/task-model.md` argues the global Task FSM (9 states + half a dozen orthogonal flags) is the wrong abstraction and proposes orthogonal decomposition: `Task { clarified, intent ∈ {next, maybe, trash}, done_at, blockers }` plus a first-class `FocusSession` entity, plus a `TimeLog` table replacing the imperative `time_spent_minutes` accumulation. Issue TMaYaD/Jeeves#185 is the load-bearing change.
+
+The naive way to ship #185 is one XXL PR that swaps the FSM, introduces FocusSession, retires `selected_for_today`/`in_progress_since`/`time_spent_minutes`, deletes ritual-bypass DAO methods, and rewrites the planning ritual UI. That's ~42 files, ~10 heavily FSM-coupled test files, and unreviewable in one pass.
+
+This plan breaks the work into a sequence of full-stack atomic PRs that land **one behind the other** (not in parallel). Each PR is a vertical slice — schema, DAO, UI, tests for one concept — reviewable on its own and individually revertable. The `state` column retires incrementally: each strip-PR merges one of its values into `next_action`, shrinks the CHECK constraint, and removes the now-dead UI/DAO/test surface for that state. The column itself drops in the final cleanup PR, when only `next_action` is left. FocusSession lands in a single load-bearing PR that also retires `selected_for_today` and `state = 'in_progress'` — no flag-switching, no dual-write bookkeeping.
+
+The app is in alpha, so:
+- Eager data migration (no lazy-on-read shenanigans).
+- No feature flags, no FSM-and-FocusSession coexistence period at the release level.
+- Backwards-compat shims, deprecated-column shadows, etc., are explicitly **out of scope** — the codebase moves forward in lockstep.
+
+## Decisions locked in this session
+
+These resolve enough of `docs/proposals/task-model.md` §8 to start cutting code. The rest of §8 stays open and can be settled later. The same decisions are mirrored into the proposal in §4.5, §6, §7.1, §7.2, §8 (as resolved questions), and §9.1.
+
+1. **Each PR is a full-stack atomic vertical slice.** Schema, DAO, UI, tests all move together for one concept per PR. Keeps changes reviewable, testable end-to-end at each step, and trivially revertable.
+
+2. **PRs land sequentially, not in parallel.** Tracking and review are easier when changes go in one behind the other than when several feature branches diverge from main.
+
+3. **One-shot is a *release* concern, not a *column* concern.** No feature flags, no dual-version code, no FSM-and-FocusSession coexisting behind a switch. But the `state` column itself gets stripped one allowed value at a time across multiple PRs. Each strip merges that state's rows into another (typically `next_action`), shrinks the CHECK constraint, and removes the now-dead UI/DAO/test surface. The `state` column itself drops only in the final cleanup PR, when `next_action` is the only remaining value.
+
+4. **No dual-write bookkeeping.** When FocusSession is introduced, it becomes the source of truth for "what is the focused task" and "which tasks are on today's plan." The retirement of `selected_for_today` / `state = 'in_progress'` happens in the same PR, not behind a flag. The other FSM states (`waiting_for`, `someday_maybe`, `inbox`, `done`) keep working as today, on the same `state` column, until their own strip-PRs come around.
+
+5. **Blockers stripped, not modeled.** The polymorphic blockers epic (TMaYaD/Jeeves#181) is **not** a prerequisite. Specifically:
+   - `state = 'scheduled'` collapses to `state = 'next_action'` with `due_date` retained. Investigation confirmed `scheduled` is half-baked: UI/screen/DAO/FSM plumbing exists, but no auto-transition on the day, and `ScheduledReviewStep` doesn't even consult `scheduledDueTodayProvider`. The state is decorative, not behavioral.
+   - `state = 'blocked'` collapses to `state = 'next_action'`, `blocked_by_todo_id` column dropped, cascade-unblock side effect deleted. Lossy on the dependency hint, acceptable in alpha.
+   - `state = 'waiting_for'` collapses to `state = 'next_action'`. The existing `waiting_for` text column on `todos` is kept as-is (no rename). The "Waiting For" list re-sources from `WHERE waiting_for IS NOT NULL`.
+   - `state = 'deferred'` collapses to `state = 'next_action'`. Per proposal §4.5, `deferred` evaporates — there is no replacement.
+
+6. **TimeLog (TMaYaD/Jeeves#182) ships without `focus_session_id`.** Adding the column on day one risks pulling FocusSession scope into the TimeLog PR. The column gets added later, in the FocusSession PR, via its own migration. TimeLog rows written before FocusSession exists simply have no session attribution; that's fine — the column is not load-bearing.
+
+7. **TimeLog row = one contiguous task-focus span.** Switching focus from task A → B → A writes three TimeLog rows. Pauses are client-side cosmetic (per existing `focus_session_provider.dart:111-125` pattern) and do **not** split rows — breaks count as work. Pomodoro sprints are orthogonal: they do not write TimeLog rows. This kills the existing `_logSprintTimeToTask` write path at `app/lib/providers/sprint_timer_provider.dart:612-632` in the TimeLog PR (otherwise we'd double-count).
+
+8. **FocusSession PK shape.** `id UUID PK` plus a partial unique index `(user_id) WHERE ended_at IS NULL`. Many sessions per user over time, exactly one open at any moment. Multiple task spans per session, multiple sessions per day allowed.
+
+9. **PR TMaYaD/Jeeves#140 (Evening Shutdown) held.** Salvage-or-rewrite decision deferred until the FocusSession PR is sufficiently advanced. The session-review wrap-up flow is the final follow-up PR; #140 may be lifted into it or dropped in favor of a clean rewrite at that point.
+
+10. **Proposal §6 framing revised.** `Timer.intervals: List<{start, end}>` was misleading. Per decision 7, a TimeLog row IS a (start, end) pair scoped to one task; a FocusSession's "intervals" are just its TimeLog rows. The list-of-intervals-per-task framing implied splitting on pause, which we're now ruling out. The proposal's §6 has been updated to match.
+
+11. **`completed_at` is renamed to `done_at`, not parallel-added.** PR G performs `ALTER TABLE todos RENAME COLUMN completed_at TO done_at` rather than adding a new column and backfilling from the old one. Same semantics (non-null means done; value is when), one less column to ever drop later.
+
+12. **TimeLog has zero historical backfill.** When PR D ships, `time_spent_minutes` continues to be the source of truth for pre-existing time. New time gets logged via TimeLog and updates the cache. The cache may be inconsistent for tasks that had pre-existing time AND get new TimeLog entries; that's acceptable — `time_spent_minutes` is treated as a cache that can be invalidated freely. Instrumentation/metrics get added later to decide whether to drop the cache and switch to live `SUM(TimeLog)` reads.
+
+13. **`Intent` enum is 3-value from day one.** PR E lands `{next, maybe, trash}` at the column level. UI surfaces only `next` and `maybe` for now. The `trash` UX is a separate design.
+
+14. **PR I's UI scope is "wire, don't rewrite."** The existing planning ritual screens (`planning_ritual_screen.dart` and steps) get wired to call `FocusSessionDao.openSession` instead of `selectForToday`. The focus screen reads `focus_session.current_task_id` instead of `state == 'in_progress'`. **The new ritual design from TMaYaD/Jeeves#180 is out of scope for PR I** — it lands in follow-up PRs after #180. If implemented right, PR I's removed LoC exceeds added LoC.
+
+## PR sequence
+
+The full sequence, in landing order:
+
+```
+A.  Strip `scheduled` state                     (cleanup, dead-ish code)
+B.  Strip `blocked` state + blockers            (cleanup)
+C.  Strip `deferred` state                      (cleanup; it evaporates)
+D.  TimeLog (#182), no focus_session_id         (additive, replaces time-spent accumulation)
+E.  Strip `someday_maybe` → introduce `intent`  (additive col + state strip)
+F.  Strip `inbox` → introduce `clarified`       (additive col + state strip)
+G.  Strip `done` → introduce `done_at`          (additive col + state strip)
+H.  Strip `waiting_for` state                   (re-source list from `waiting_for` text col)
+I.  FocusSession + strip `in_progress`          (load-bearing; retires `selected_for_today`)
+J.  Final cleanup: drop `state` column          (the FSM is now empty; delete the husk)
+K.  focus_session_review wrap-up UI             (follow-up; replaces / salvages PR #140)
+```
+
+**Hard ordering constraints:**
+- D (TimeLog) must precede I (FocusSession), because I adds the `focus_session_id` FK to `time_logs` and wires `setCurrentTask` to drive TimeLog open/close.
+- A, B, C, E, F, G, H must all precede J, because J only drops the column once `next_action` is the sole remaining value.
+- I (FocusSession) doesn't strictly require E/F/G/H to ship first, but the planning-ritual rewrite inside I gets simpler if intent/clarified/done_at already exist (so the new list views can already filter on them).
+- K depends on I.
+
+**Soft ordering rationale:**
+- A/B/C first: they're isolated cleanup, low risk, set the rhythm.
+- D before E/F/G/H: TimeLog is foundational; later state-strip PRs can ignore time tracking entirely.
+- E/F/G order is interchangeable.
+- H (waiting_for) before I (FocusSession) keeps I focused on focus-session semantics rather than waiting-for re-sourcing.
+- I is the load-bearing one; ships when all the smaller strips are out of the way.
+- J is one-line in the column sense, but cleans up the FSM enum, `GtdStateMachine`, transition tests, ritual-bypass DAO methods.
+
+**No "wire FocusSession alongside FSM" intermediate.** When I lands, FocusSession becomes the single source of truth for focus selection and current-task pointer in the same PR. `selected_for_today` and `state = 'in_progress'` retire in I, no flag-switching, no dual-write code that gets thrown away.
+
+## PR A — Strip `scheduled` state
+
+**Goal:** retire the half-baked `scheduled` state. First in the sequence because it's pure decorative removal — no replacement column needed; `due_date` already does the real work.
+
+**Why this lands first:** investigation confirmed `scheduled` carries no behavior beyond a separate list view. There's no auto-transition on the date, no notification, no planning-ritual integration. `due_date` is the only piece that does real work, and it's already a separate column that survives the collapse.
+
+**Migration:**
+```sql
+UPDATE todos SET state = 'next_action' WHERE state = 'scheduled';
+-- due_date retained as-is
+-- shrink GTD_STATES CHECK constraint to drop 'scheduled'
+```
+
+**Files to change:**
+- `backend/alembic/versions/00XX_collapse_scheduled_state.py` — new migration.
+- `backend/app/todos/models.py:30` — remove `'scheduled'` from `GTD_STATES`.
+- `backend/app/todos/routes.py:41-42` — remove `state=scheduled` filter handling.
+- `app/lib/models/todo.dart:9-46` — remove `GtdState.scheduled` enum value; update `fromString()` to map legacy `'scheduled'` → `nextAction` defensively for stale local DBs.
+- `app/lib/models/gtd_state_machine.dart:38, 50-54` — remove `scheduled` from `allowedTransitions`.
+- `app/lib/database/daos/inbox_dao.dart:151-190` — delete `transitionInboxToScheduled` (the two-hop atomic method that exists only because the FSM forbade `inbox → scheduled`).
+- `app/lib/database/daos/todo_dao.dart:338-350` — delete `watchScheduledDueToday`.
+- `app/lib/providers/daily_planning_provider.dart:160-165` — delete `scheduledDueTodayProvider`.
+- `app/lib/providers/daily_planning_provider.dart:307-323` — `processInboxItem` collapses to a single transition.
+- `app/lib/providers/gtd_lists_provider.dart:46-51` — delete `scheduledProvider`.
+- `app/lib/screens/scheduled/scheduled_screen.dart` — delete file.
+- `app/lib/screens/planning/steps/scheduled_review_step.dart:23-24` — drop the scheduled-specific sort branch (or delete the step entirely if redundant — verify in implementation).
+- `app/lib/router.dart:11, 87-88` — remove the `/scheduled` route.
+- `app/lib/screens/app_shell.dart` — remove the scheduled count from the nav bar.
+- Tests:
+  - `app/test/models/gtd_state_machine_test.dart` — remove scheduled-row tests, including `inbox → scheduled is rejected`.
+  - `app/test/database/inbox_dao_test.dart:106` — remove the two-hop assertion.
+  - `app/test/database/planning_dao_test.dart:128-174` — remove the scheduled-due-today tests.
+- `NOTES.md` — append a one-liner under today's date noting the collapse and that the `inbox → scheduled` two-hop workaround (NOTES 2026-04-21 lines 41-42) retires with it.
+
+**Reversibility:** if we want `scheduled` back later, it returns as a `TimeBlocker` under TMaYaD/Jeeves#181 — a much cleaner home than its current FSM perch.
+
+## PR B — Strip `blocked` state and blocker functionality
+
+**Goal:** retire the `blocked` state and the `blocked_by_todo_id` column. The cascade-unblock side effect on `done` retires with them. Lossy on the dependency hint between tasks — acceptable in alpha.
+
+**Migration:**
+```sql
+UPDATE todos SET state = 'next_action' WHERE state = 'blocked';
+ALTER TABLE todos DROP COLUMN blocked_by_todo_id;
+-- shrink GTD_STATES CHECK constraint to drop 'blocked'
+```
+
+**Files to change:**
+- `backend/alembic/versions/00XX_strip_blocked_state.py` — new migration.
+- `backend/app/todos/models.py` — remove `'blocked'` from `GTD_STATES`; remove `blocked_by_todo_id` column.
+- `backend/app/todos/schemas.py` — drop `blocked_by_todo_id` from read/write schemas.
+- `backend/app/todos/routes.py` — remove `state=blocked` filter handling.
+- `app/lib/models/todo.dart` — remove `GtdState.blocked`; remove `blockedByTodoId` field; update `fromString()` to map legacy `'blocked'` → `nextAction`.
+- `app/lib/models/gtd_state_machine.dart` — remove `blocked` from `allowedTransitions`.
+- `app/lib/database/daos/todo_dao.dart` — delete cascade-unblock side effect on `done` transition. Remove `blocked_by_todo_id` references in `_buildTransitionCompanion`. Drop the `state=blocked`/`state=nextAction` special case in `updateFields` (lines 484-543). Delete any blocker-specific watchers.
+- `app/lib/database/powersync_schema.dart` — drop `blocked_by_todo_id` from the view.
+- `app/lib/database/tables.dart` — drop column from Drift schema.
+- UI: any "blocked by" picker / link UI gets deleted (search `blockedByTodoId` references across `app/lib/`). Any list view filtered to `state = blocked` (search `gtd_lists_provider.dart`) — delete.
+- Tests: `app/test/database/todo_dao_test.dart` — strip cascade-unblock test and blocker-related tests. `app/test/models/gtd_state_machine_test.dart` — remove blocked rows.
+
+**Reversibility:** comes back via TMaYaD/Jeeves#181 (polymorphic blockers) when typed blockers get designed.
+
+## PR C — Strip `deferred` state
+
+**Goal:** retire `deferred`. Per proposal §4.5, `deferred` evaporates — there is no replacement column. The verb "defer" gets repurposed later by PR E to mean "set intent = maybe."
+
+**Migration:**
+```sql
+UPDATE todos SET state = 'next_action' WHERE state = 'deferred';
+-- shrink GTD_STATES CHECK constraint to drop 'deferred'
+```
+
+**Files to change:**
+- `backend/alembic/versions/00XX_strip_deferred_state.py` — new migration.
+- `backend/app/todos/models.py` — remove `'deferred'` from `GTD_STATES`.
+- `app/lib/models/todo.dart` — remove `GtdState.deferred`; map legacy `'deferred'` → `nextAction`.
+- `app/lib/models/gtd_state_machine.dart` — remove `deferred` from `allowedTransitions`.
+- `app/lib/database/daos/todo_dao.dart:417-438` — delete `deferTaskToSomeday` (it currently transitions to `deferred`). Callers either route to `deferTaskToMaybe` (introduced in PR E) or get inlined as a state-no-op.
+- `app/lib/providers/gtd_lists_provider.dart` — delete any `deferredProvider`.
+- UI: search `deferred` references across `app/lib/screens/`; delete list views and chip styles.
+- Tests: `app/test/models/gtd_state_machine_test.dart` — remove deferred rows.
+
+**Out of scope:** introducing `intent = 'maybe'` — that's PR E.
+
+## PR D — TimeLog (TMaYaD/Jeeves#182)
+
+**Goal:** introduce the `time_logs` table and route all task-focus time accounting through it. Additive only — no behavior visible to the user changes. Ships **without** `focus_session_id`; that column is added in PR I when FocusSession lands.
+
+**Schema:**
+```
+time_logs
+  id          UUID PK
+  user_id     UUID NOT NULL              -- denormalized for PowerSync
+  task_id     UUID NOT NULL FK → todos.id
+  started_at  TIMESTAMPTZ NOT NULL
+  ended_at    TIMESTAMPTZ NULL           -- null = currently active
+```
+
+Partial unique index `(user_id) WHERE ended_at IS NULL` — at most one open TimeLog row per user. Mirrors the FSM's "at most one in-progress" invariant at the time-tracking layer, and survives the cutover when FocusSession takes over.
+
+**Files to change:**
+- `backend/alembic/versions/00XX_add_time_logs.py` — new migration. Table + indexes only.
+- `backend/app/todos/models.py` — `TimeLog` SQLAlchemy model.
+- `backend/app/todos/schemas.py` — Pydantic read schema. No write schema — clients write through the synced view.
+- `app/lib/database/powersync_schema.dart` — add `time_logs` to `powersyncSchema`. Use the same view-with-INSTEAD-OF-trigger pattern as `todos`/`tags`/`todo_tags` (NOTES.md 2026-04-22). Apply `_addColumnIfTable` helper for the Drift onUpgrade path (NOTES.md 2026-04-22 lines 53-55).
+- `app/lib/database/tables.dart` — Drift table for the `NativeDatabase.memory()` test path.
+- `app/lib/database/daos/time_log_dao.dart` — new DAO. Methods: `openLog({taskId})`, `closeLog({taskId})`, `watchActiveLog(userId)`, `totalMinutesForTask(taskId)`.
+- `app/lib/database/daos/todo_dao.dart:267-276` — replace `time_spent_minutes` accumulation in `_buildTransitionCompanion` with `TimeLogDao.closeLog(taskId)` on leave-`in_progress`. Replace `in_progress_since` stamp on enter-`in_progress` with `TimeLogDao.openLog(taskId)`. `transitionState` still exists at this point (FSM not retired yet); these calls slot into the existing transition flow.
+- `app/lib/providers/sprint_timer_provider.dart:612-632` — **delete** `_logSprintTimeToTask`. Pomodoro stops writing time directly. Sprint-number display (`sprint_timer_provider.dart:706`) reads `TimeLogDao.totalMinutesForTask` instead.
+- `infra/powersync/sync-config.yaml:35-54` — add `by_user_time_logs` bucket, filter by `user_id` (mirror `by_user_todos`).
+- `app/test/database/time_log_dao_test.dart` — new tests: open/close, single-active invariant, totalMinutesForTask correctness, multi-row-per-task within a span.
+- `app/test/database/todo_dao_test.dart` — update existing time-tracking tests to assert TimeLog rows instead of `time_spent_minutes` increments. The "at most one in-progress per user" guard test stays as-is (still enforced via `transitionState`).
+
+**`time_spent_minutes` strategy:** keep as denormalized cache, recomputed on TimeLog write. Display sites continue reading the column; cheap. Pre-existing time stays accurate (the existing value is a one-time sum at migration time; new time gets added via TimeLog → cache update). Drop the column in PR J if desired, or leave as cache indefinitely.
+
+**Out of scope for PR D:** anything that mutates `state` semantics, anything that touches FocusSession (table doesn't exist yet), anything UI-visible. No `focus_session_id` column on `time_logs` — added in PR I.
+
+## PR E — Strip `someday_maybe` → introduce `intent` column
+
+**Goal:** add the `intent` column, migrate `someday_maybe` rows onto it, drop `someday_maybe` from the FSM. Full-stack atomic: schema + DAO + UI + tests in one PR.
+
+**Schema:**
+```sql
+ALTER TABLE todos ADD COLUMN intent TEXT NOT NULL DEFAULT 'next';  -- 'next' | 'maybe' | 'trash'
+UPDATE todos SET intent = 'maybe', state = 'next_action' WHERE state = 'someday_maybe';
+-- shrink GTD_STATES CHECK constraint to drop 'someday_maybe'
+```
+
+`'trash'` is included in the column domain from day one (cheap) but no UI surfaces it yet.
+
+**Files to change:**
+- `backend/alembic/versions/00XX_intent_strip_someday.py` — new migration.
+- `backend/app/todos/models.py` — add `intent` column; remove `'someday_maybe'` from `GTD_STATES`.
+- `backend/app/todos/schemas.py` — add `intent` to read/write schemas.
+- `app/lib/models/todo.dart` — add `intent` field; add `Intent` enum (`next`, `maybe`, `trash`); remove `GtdState.somedayMaybe`; map legacy `'someday_maybe'` → `nextAction` in `fromString()`.
+- `app/lib/models/gtd_state_machine.dart` — remove `someday_maybe` from `allowedTransitions`.
+- `app/lib/database/powersync_schema.dart` + `app/lib/database/tables.dart` — add `intent` column.
+- `app/lib/database/daos/todo_dao.dart` — replace `watchSomedayMaybe` (or equivalent) with `watchMaybe` reading `WHERE intent = 'maybe' AND done_at IS NULL`. Replace any `transitionState(somedayMaybe)` callers with `setIntent(id, maybe)`. Reinstate the "defer" verb deleted in PR C as `deferTaskToMaybe` → `setIntent(maybe)`.
+- `app/lib/providers/gtd_lists_provider.dart` — `somedayMaybeProvider` → `maybeProvider` reading the new filter.
+- UI: rename Someday/Maybe screen header if needed; the chip/picker that previously set `state = someday_maybe` now calls `setIntent(maybe)`.
+- Tests: rewrite someday tests around intent. `gtd_state_machine_test.dart` — remove someday rows.
+
+**Out of scope:** the `'trash'` UX and any UI for it.
+
+## PR F — Strip `inbox` → introduce `clarified` column
+
+**Goal:** replace the `state = 'inbox'` semantics with a `clarified` boolean. The Inbox screen re-sources from `WHERE clarified = false`. Per proposal §6.4, `clarified` is an internal detail — not surfaced as a public API field.
+
+**Schema:**
+```sql
+ALTER TABLE todos ADD COLUMN clarified BOOLEAN NOT NULL DEFAULT TRUE;
+UPDATE todos SET clarified = false, state = 'next_action' WHERE state = 'inbox';
+-- shrink GTD_STATES CHECK constraint to drop 'inbox'
+```
+
+New rows from the capture/inbox flow set `clarified = false` at insert. Rows created by any other path default to `clarified = true`.
+
+**Files to change:**
+- `backend/alembic/versions/00XX_clarified_strip_inbox.py` — new migration.
+- `backend/app/todos/models.py` — add `clarified` column; remove `'inbox'` from `GTD_STATES`.
+- `backend/app/todos/schemas.py` — keep `clarified` internal; do not expose in the public read/write schemas.
+- `app/lib/models/todo.dart` — add `clarified` field; remove `GtdState.inbox`; map legacy `'inbox'` → `nextAction`.
+- `app/lib/models/gtd_state_machine.dart` — remove `inbox` from `allowedTransitions`.
+- `app/lib/database/powersync_schema.dart` + `app/lib/database/tables.dart` — add `clarified` column.
+- `app/lib/database/daos/inbox_dao.dart` — capture flow inserts with `clarified = false`. The "process inbox item" path becomes "set `clarified = true`" plus whatever other field updates the user made (e.g. set `intent`, set `due_date`).
+- `app/lib/database/daos/todo_dao.dart` — replace inbox-state watchers with `watchInbox` reading `WHERE clarified = false`.
+- `app/lib/providers/gtd_lists_provider.dart` — `inboxProvider` reads the new filter.
+- `app/lib/providers/daily_planning_provider.dart:307-323` — `processInboxItem` no longer transitions state; it updates fields and sets `clarified = true`.
+- UI: Inbox screen reads from the new provider. Capture screen unchanged (still routes through `inbox_dao`).
+- Tests: rewrite inbox tests around `clarified`. `gtd_state_machine_test.dart` — remove inbox rows.
+
+## PR G — Strip `done` → rename `completed_at` to `done_at`
+
+**Goal:** replace the terminal `state = 'done'` with a non-null `done_at` timestamp. No new column added — just rename the existing `completed_at` (same semantics). The Done list reads `WHERE done_at IS NOT NULL`.
+
+**Schema:**
+```sql
+ALTER TABLE todos RENAME COLUMN completed_at TO done_at;
+-- defensive: any 'done' rows that somehow had NULL completed_at get backfilled from updated_at
+UPDATE todos SET done_at = updated_at WHERE state = 'done' AND done_at IS NULL;
+UPDATE todos SET state = 'next_action' WHERE state = 'done';
+-- shrink GTD_STATES CHECK constraint to drop 'done'
+```
+
+**Files to change:**
+- `backend/alembic/versions/00XX_rename_completed_at_strip_done.py` — new migration.
+- `backend/app/todos/models.py` — rename `completed_at` field to `done_at`; remove `'done'` from `GTD_STATES`.
+- `backend/app/todos/schemas.py` — rename `completed_at` to `done_at` in read/write schemas. Search the codebase for any analytics or other readers of `completed_at` and update them.
+- `app/lib/models/todo.dart` — rename `completedAt` field to `doneAt`; remove `GtdState.done`; map legacy `'done'` → `nextAction`.
+- `app/lib/models/gtd_state_machine.dart` — remove `done` from `allowedTransitions`. (Cascade-unblock is already gone via PR B, so this is just removing the destination.)
+- `app/lib/database/powersync_schema.dart` + `app/lib/database/tables.dart` — rename column.
+- `app/lib/database/daos/todo_dao.dart` — add `markDone(id)` that sets `done_at = now()`. Replace `transitionState(...done)` callsites with `markDone`. Add `watchDone` reading `WHERE done_at IS NOT NULL`.
+- `app/lib/providers/gtd_lists_provider.dart` — `doneProvider` reads the new filter.
+- UI: the "complete" / checkmark control calls `markDone` instead of `transitionState(done)`. The Done screen reads from the new provider. Replace any `completedAt` UI references with `doneAt`.
+- Tests: rewrite done tests around `done_at`; rename `completedAt` references throughout. `gtd_state_machine_test.dart` — remove done rows.
+
+## PR H — Strip `waiting_for` state
+
+**Goal:** retire `state = 'waiting_for'`. The existing `waiting_for` text column on `todos` (the "who/what we're waiting on") is **kept as-is** — the Waiting For list re-sources from `WHERE waiting_for IS NOT NULL` plus the standard actionable filters.
+
+**Migration:**
+```sql
+UPDATE todos SET state = 'next_action' WHERE state = 'waiting_for';
+-- shrink GTD_STATES CHECK constraint to drop 'waiting_for'
+-- waiting_for column retained
+```
+
+**Files to change:**
+- `backend/alembic/versions/00XX_strip_waiting_for_state.py` — new migration.
+- `backend/app/todos/models.py` — remove `'waiting_for'` from `GTD_STATES`.
+- `app/lib/models/todo.dart` — remove `GtdState.waitingFor`; map legacy `'waiting_for'` → `nextAction`.
+- `app/lib/models/gtd_state_machine.dart` — remove `waiting_for` from `allowedTransitions`.
+- `app/lib/database/daos/todo_dao.dart` — replace `watchWaitingFor` (state-based) with one reading `WHERE waiting_for IS NOT NULL AND clarified = true AND done_at IS NULL AND intent = 'next'`.
+- `app/lib/providers/gtd_lists_provider.dart` — `waitingForProvider` reads the new filter.
+- UI: the "convert to waiting for" verb sets the `waiting_for` text column instead of transitioning state. The Waiting For screen reads from the new provider.
+- Tests: rewrite waiting-for tests around the column-based filter.
+
+**Out of scope:** any Waiting For tag-system migration (open question; column path is cheaper).
+
+## PR I — FocusSession + strip `in_progress` (load-bearing)
+
+**Goal:** introduce FocusSession as the single source of truth for "what's the focused task" and "which tasks are on today's plan." Retire `state = 'in_progress'`, `selected_for_today`, `daily_selection_date`, and `in_progress_since` in the same PR. No flag-switching, no dual-write code that gets thrown away.
+
+By the time this PR lands, only `next_action` and `in_progress` remain in the `state` column. After this PR, only `next_action` remains. PR J then drops the column entirely.
+
+**Schema:**
+```sql
+-- new tables
+CREATE TABLE focus_sessions (
+  id              UUID PRIMARY KEY,
+  user_id         UUID NOT NULL,
+  started_at      TIMESTAMPTZ NOT NULL,
+  ended_at        TIMESTAMPTZ NULL,
+  current_task_id UUID NULL REFERENCES todos(id)
+);
+CREATE UNIQUE INDEX focus_sessions_one_open_per_user
+  ON focus_sessions(user_id) WHERE ended_at IS NULL;
+
+CREATE TABLE focus_session_tasks (
+  focus_session_id UUID NOT NULL REFERENCES focus_sessions(id),
+  task_id          UUID NOT NULL REFERENCES todos(id),
+  position         INT  NOT NULL,
+  PRIMARY KEY (focus_session_id, task_id)
+);
+
+-- wire TimeLog to FocusSession (the deferred step from PR D)
+ALTER TABLE time_logs ADD COLUMN focus_session_id UUID NULL REFERENCES focus_sessions(id);
+
+-- backfill: synthesize one open FocusSession per user that has either
+--   (a) any task with state = 'in_progress', or
+--   (b) any task with selected_for_today = true.
+-- Members come from selected_for_today rows (and the in_progress task if any).
+-- current_task_id := the in_progress task if any, else NULL.
+-- After backfill: collapse state = 'in_progress' rows to state = 'next_action'.
+
+UPDATE todos SET state = 'next_action' WHERE state = 'in_progress';
+ALTER TABLE todos DROP COLUMN selected_for_today;
+ALTER TABLE todos DROP COLUMN daily_selection_date;
+ALTER TABLE todos DROP COLUMN in_progress_since;
+-- shrink GTD_STATES CHECK constraint to drop 'in_progress'
+```
+
+The "at most one in-progress per user" invariant is now enforced structurally by the partial unique index on `focus_sessions`, replacing the FSM-level guard.
+
+**Files to change (schema / sync / models):**
+- `backend/alembic/versions/00XX_focus_sessions_strip_in_progress.py` — new migration.
+- `backend/app/todos/models.py` — `FocusSession`, `FocusSessionTask` models. Remove `'in_progress'` from `GTD_STATES`. Drop `selected_for_today`, `daily_selection_date`, `in_progress_since`. Add `focus_session_id` to `TimeLog`.
+- `backend/app/todos/schemas.py` — read schemas for the new tables.
+- `app/lib/database/powersync_schema.dart` + `app/lib/database/tables.dart` — add new tables; drop the dropped columns; add `focus_session_id` to `time_logs`. Verify whether `_dropColumnIfTable` exists; create if not (NOTES.md 2026-04-22 line 55).
+- `infra/powersync/sync-config.yaml` — add `by_user_focus_sessions` and `by_user_focus_session_tasks` buckets. `by_user_time_logs` already exists.
+- `app/lib/models/todo.dart` — remove `GtdState.inProgress`; remove `selectedForToday`, `dailySelectionDate`, `inProgressSince` fields; map legacy `'in_progress'` → `nextAction`.
+- `app/lib/models/gtd_state_machine.dart` — remove `in_progress` from `allowedTransitions`. (After this, only `next_action` is in the FSM. The file gets deleted in PR J.)
+
+**Files to change (DAO):**
+- `app/lib/database/daos/focus_session_dao.dart` — new DAO. Methods: `openSession({userId, taskIds})`, `closeSession({sessionId})`, `setCurrentTask({sessionId, taskId?})`, `watchActiveSession(userId)`, `watchSessionTasks(sessionId)`. `setCurrentTask` is the meeting point with TimeLog: with non-null `taskId` it closes any open TimeLog row and opens a new one with `focus_session_id = sessionId`; with null, it closes the open row and clears `current_task_id`.
+- `app/lib/database/daos/time_log_dao.dart` — extend `openLog` to accept optional `focusSessionId`.
+- `app/lib/database/daos/todo_dao.dart:267-300` — strip the `_buildTransitionCompanion` branches that handle `in_progress` enter/leave (TimeLog open/close moves to `setCurrentTask`).
+- `app/lib/database/daos/todo_dao.dart:372-414` — delete `selectForToday`, `skipForToday`, `undoReview`, `clearTodaySelections`, `watchSelectedForToday`, `watchNextActionsForPlanning`. Callers move to `FocusSessionDao`.
+
+**Files to change (ritual / UI — wire, do NOT rewrite):**
+
+PR I's UI scope is deliberately minimal: thread the existing screens through FocusSession instead of FSM/`selected_for_today`. The new ritual UX from TMaYaD/Jeeves#180 lands in follow-up PRs after #180 ships its design.
+
+- `app/lib/providers/daily_planning_provider.dart` — replace `selectForToday(...)` write paths with `FocusSessionDao.openSession({taskIds})`. Read paths that consult `selected_for_today` switch to `watchSessionTasks`. `planningToday()` and date arithmetic disappear; FocusSession owns its own start/end timestamps. This kills the `project_day_boundary` bug class structurally.
+- `app/lib/screens/planning/planning_ritual_screen.dart` and steps — minimal change: the final step calls `FocusSessionDao.openSession({taskIds: selected})` instead of per-task `selectForToday`. Visual structure unchanged.
+- `app/lib/screens/focus_screen.dart` and `app/lib/screens/active_focus_screen.dart` — read `focus_session.current_task_id` via `watchActiveSession`. Starting a task calls `setCurrentTask(taskId)` (transitively opens a TimeLog row). Stopping calls `setCurrentTask(null)`. Completing calls `markDone(taskId)` and then `setCurrentTask(null)`.
+- `app/lib/providers/sprint_timer_provider.dart` — read `focus_session.current_task_id` instead of `state == 'in_progress'` to know which task the sprint applies to.
+- `app/lib/providers/focus_session_provider.dart:111-125` — existing client-side pause/resume stays as-is; explicitly does not split TimeLog rows.
+
+**LoC expectation:** removed > added. If the diff trends the other way, audit for accidental scope creep into TMaYaD/Jeeves#180 territory.
+
+**Tests:**
+- New `app/test/database/focus_session_dao_test.dart`: open/close, single-active invariant per user, current-task pointer flips, task list immutability post-open, TimeLog open/close coupling via `setCurrentTask`.
+- `app/test/database/todo_dao_test.dart` — strip the "at most one in_progress" test (now structural via the partial unique index), strip `selectForToday`/`skipForToday` tests.
+- `app/test/database/planning_dao_test.dart` — rewrite around FocusSession.
+- `app/test/providers/daily_planning_provider_test.dart` — rewrite around FocusSession lifecycle.
+- New `app/test/integration/focus_session_lifecycle_test.dart` — end-to-end: open session with N tasks, set current, switch current (assert TimeLog rows split), close session (assert TimeLog row closes, current_task_id clears).
+
+**Out of scope:**
+- New ritual / planning UX (TMaYaD/Jeeves#180). PR I wires the existing UI to FocusSession verbatim; the redesigned flow lands in follow-up PRs after #180 ships its design.
+- Session-review wrap-up UI (per-task rollover/leave/maybe). That's PR K.
+- Polymorphic blockers (TMaYaD/Jeeves#181).
+- Clarify & Organise rework (TMaYaD/Jeeves#184).
+
+## PR J — Final cleanup: drop the FSM
+
+**Goal:** with `next_action` the only remaining `state` value, drop the column and delete the FSM scaffolding.
+
+**Schema:**
+```sql
+ALTER TABLE todos DROP COLUMN state;
+-- time_spent_minutes is kept as a cache; instrumentation/metrics will inform a later drop decision.
+-- completed_at is already gone (PR G renamed it to done_at).
+```
+
+**Files to change:**
+- `backend/alembic/versions/00XX_drop_state_column.py` — new migration.
+- `backend/app/todos/models.py` — remove `state` column and `GTD_STATES` constant.
+- `backend/app/todos/schemas.py` — remove `state` from read/write schemas.
+- `backend/app/todos/routes.py` — remove any state-filter parameters.
+- `app/lib/models/todo.dart:9-46` — delete `GtdState` enum and `fromString`. Keep `Intent`.
+- `app/lib/models/gtd_state_machine.dart` — **delete file**.
+- `app/lib/database/daos/todo_dao.dart:205-300` — delete `transitionState` and `_buildTransitionCompanion` (now empty / only-next_action). The simple field-update methods (`markDone`, `setIntent`, `updateFields`) introduced across PRs E/F/G remain.
+- `app/lib/database/powersync_schema.dart` + `app/lib/database/tables.dart` — drop `state` column.
+- `infra/powersync/sync-config.yaml` — drop `state` from select lists.
+- `app/test/models/gtd_state_machine_test.dart` — **delete file**.
+- `app/test/database/todo_dao_test.dart` — strip remaining `transitionState` tests.
+
+**Verification of completeness:** grep for `transitionState`, `GtdState`, `gtd_state_machine`, `GTD_STATES` across both `app/` and `backend/`. Zero references after this PR.
+
+## PR K — focus_session_review wrap-up UI (follow-up)
+
+**Goal:** the wrap-up flow at session close where the user picks per-task disposition (rollover, leave, maybe / trash).
+
+**Depends on:** PR I (FocusSession in place) and PR J (FSM dropped).
+
+**Scope:** broken out so PR I stays focused on the cutover. This is where PR TMaYaD/Jeeves#140 (Evening Shutdown) gets revisited — salvage the UI scaffolding, rewrite the data interactions to use the new model. Per Decision 9, salvage-vs-rewrite is decided after PR I lands and the new shape is visible.
+
+**Sketched here only so the sequence terminates cleanly.** Detailed plan deferred until PR I is in flight.
+
+## Investigation tasks (not blockers)
+
+One spike worth doing during PR D so the recipe is right before PR I follows the same pattern:
+
+- **PowerSync sync-rule pattern for new tables.** Verify that `time_logs` (PR D) rides the same `by_user_*` bucket shape as `todos` without surprises. Whatever pattern lands in PR D becomes the recipe for `focus_sessions` / `focus_session_tasks` in PR I.
+
+## Verification
+
+Per-PR (each must pass before merge):
+- `make lint` and `make test` clean.
+- New DAO tests pass (PR D introduces TimeLog tests; PR I introduces FocusSession tests).
+- Migration round-trips on a seeded DB: spin up an alpha-shaped DB with rows in every state currently allowed, run the migration, assert the post-state matches the backfill table for that PR (PRs A, B, C, E, F, G, H, I, J).
+- PowerSync end-to-end on emulator with two devices: write on device A, observe on device B. Required for any PR that adds/removes a synced table or column (D, I, J in particular). Use the emulator tap coordinates in `docs/TESTING.md`.
+
+State-strip PRs (A, B, C, E, F, G, H):
+- After the migration runs, the relevant state value is absent from `GTD_STATES` and absent from any persisted row. The replacement filter (where applicable: `intent`, `clarified`, `done_at`, `waiting_for`) drives the corresponding list view.
+- `transitionState` callers that previously targeted the stripped state either route to a new field-update method (e.g. `markDone`, `setIntent`) or are deleted.
+
+Cutover-specific (PR I):
+- Manual smoke: open the planning ritual, select 3 tasks, start the session, switch focus between them, complete one, close the session. Verify in DB: one `focus_sessions` row with the expected lifecycle, three `focus_session_tasks` rows, ≥3 `time_logs` rows with correct `started_at`/`ended_at` and `focus_session_id`. The completed task has `done_at` set; the other two retain `intent = 'next'`.
+- Verify the `project_day_boundary` bug class is gone: change device timezone mid-session and confirm the open session does not flip identity.
+- Verify Pomodoro: start a sprint mid-task-span, let it expire, verify a sprint-end notification fires AND no extra TimeLog row is written (the running TimeLog row stays open across the sprint boundary).
+
+Final-cleanup-specific (PR J):
+- Grep `transitionState`, `GtdState`, `gtd_state_machine`, `GTD_STATES`, `state` (as a column name in queries) across `app/` and `backend/`. Zero references after PR J.
+
+End-to-end (after PR K):
+- Full ritual loop: morning planning → focus session with task switching and pauses → session-review wrap-up with per-task disposition → next morning's planning shows the rolled-over tasks pre-selected.
+
+## File touchpoint summary
+
+Read-the-room reference for trixy / future agents:
+
+| Concern | Today (file:line) | After PR J | Retired by |
+|---|---|---|---|
+| State enum | `backend/app/todos/models.py:30`, `app/lib/models/todo.dart:9-46`, `app/lib/models/gtd_state_machine.dart:28-77` | Deleted | A → I shrink the values; J drops the column and FSM file |
+| Transition logic | `app/lib/database/daos/todo_dao.dart:205-300` | Replaced with field-update methods | Each strip PR converts its callers; J deletes the husk |
+| Time accumulation | `app/lib/database/daos/todo_dao.dart:267-276`, `app/lib/providers/sprint_timer_provider.dart:612-632` | `time_log_dao.dart` | D |
+| Focus selection | `selectForToday` / `selected_for_today` flag | `focus_session_dao.openSession` + `focus_session_tasks` | I |
+| Active task pointer | `state == 'in_progress'` + "at most one" guard | `focus_sessions.current_task_id` + partial unique index | I |
+| Blocker hint | `blocked_by_todo_id` | Removed (no replacement in alpha; TMaYaD/Jeeves#181 covers later) | B |
+| Waiting-for hint | `waiting_for` text column + `state = waiting_for` | `waiting_for` text column kept; state value gone | H |
+| "Maybe" list | `state = 'someday_maybe'` | `intent = 'maybe'` | E |
+| "Inbox" list | `state = 'inbox'` | `clarified = false` | F |
+| "Done" list | `state = 'done'` | `done_at IS NOT NULL` | G |
+| Day boundary | `planningToday()` in `daily_planning_provider.dart` | Gone — FocusSession owns timestamps | I |

--- a/docs/proposals/task-model.md
+++ b/docs/proposals/task-model.md
@@ -561,11 +561,13 @@ Rename the internal concepts to be session-relative:
 |-----------------------------|----------------------------|----------------------------|
 | Daily Planning Ritual / DPR | `focus_session_planning`   | "Plan today" / similar     |
 | Evening Shutdown            | `focus_session_review`     | "Wrap up the day" / similar|
-| (future) Weekly Planning    | `periodic_planning`        | "Plan this week"           |
-| (future) Weekly Retro       | `periodic_review`          | "Reflect on this week"     |
 
-Side benefit: `focus_session_*` and `periodic_session_*` make the §6.1
-distinction structurally obvious in code.
+The PeriodicSession concept (§6.1) doesn't exist in code yet — it will be
+born as part of #54 (Weekly Review wizard). That work should land with
+`periodic_session_*` naming from day one; there's nothing to rename.
+
+Side benefit: `focus_session_*` (now) and `periodic_session_*` (when #54
+ships) make the §6.1 distinction structurally obvious in code.
 
 ---
 

--- a/docs/proposals/task-model.md
+++ b/docs/proposals/task-model.md
@@ -3,9 +3,10 @@
 > **Status:** Domain-modelling proposal & discussion record. Not current-state
 > architecture. Implementation is unchanged at the time of writing;
 > `docs/ARCHITECTURE.md` remains the source of truth for what is built today.
-> Decisions captured here will land through follow-up issues.
+> Decisions captured here land through the rollout in
+> `docs/proposals/task-model-rollout.md` (PRs A–K against TMaYaD/Jeeves#185).
 >
-> **Date:** 2026-04-25
+> **Date:** 2026-04-25 (initial); 2026-04-26 (rollout decisions appended in §9).
 > **Origin:** Session reviewing the original Task FSM (reference SVG)
 > against the implemented FSM in `app/lib/models/gtd_state_machine.dart` and
 > `app/lib/database/daos/todo_dao.dart`.
@@ -182,20 +183,45 @@ reference FSM shows this as a labeled transition without specifying who
 triggers it. Automation is the correct call; the manual alternative leaves
 orphaned blocked tasks.
 
-### 4.5 `deferred` state — **OPEN, leaning NOISE**
+### 4.5 `deferred` state — **DECIDED — NOISE, evaporates**
 
-Used for `in_progress → deferred` (Abandon mid-day). Two readings:
+Used for `in_progress → deferred` (Abandon mid-day). Two readings were on the
+table:
 
 1. *Necessary refinement.* Distinguishes "abandoned today, still a Next
    Action" from "Someday/Maybe."
 2. *Spurious.* Equivalent to "Stop + clear `selected_for_today`," which the
    reference FSM's `Focus → Next (Return to Next)` already covers.
 
-In the proposed model (§7) the question dissolves: "abandoned today" is
+In the proposed model the question dissolves: "abandoned today" is
 expressed as `intent=next` + remove from current `FocusSession.tasks` (which
 the user may or may not actually do — see §6.3) + (optionally) `intent=maybe`
 if the user is permanently abandoning. Three values of intent + session
 membership cover the space without a `deferred` bucket.
+
+**Decided (2026-04-26 rollout planning):** `deferred` evaporates with no
+replacement column. Rows collapse to `state = 'next_action'` and the verb
+"defer" gets repurposed to mean `setIntent(maybe)` once `intent` exists.
+Lands as PR C (then E) in `docs/proposals/task-model-rollout.md`.
+
+**Sibling decisions on the other "blocker-flavoured" states** (also
+2026-04-26, also lossy-acceptable in alpha — polymorphic blockers per §6.2 /
+TMaYaD/Jeeves#181 are **not** a prerequisite for the FSM strip):
+
+- `scheduled` collapses to `state = 'next_action'` with `due_date` retained.
+  Investigation found the state half-baked: list view exists but no
+  auto-transition, no notification, and `ScheduledReviewStep` doesn't
+  consult `scheduledDueTodayProvider`. Comes back as a `TimeBlocker` under
+  TMaYaD/Jeeves#181 if needed. Lands as PR A.
+- `blocked` collapses to `state = 'next_action'`. The
+  `blocked_by_todo_id` column is **dropped** (not preserved as a hint), and
+  the cascade-unblock side effect on `done` retires with it. Lossy on the
+  task-task dependency, acceptable in alpha; comes back via TMaYaD/Jeeves#181
+  later. Lands as PR B.
+- `waiting_for` collapses to `state = 'next_action'`. The existing
+  `waiting_for` text column is kept verbatim (no rename); the "Waiting For"
+  list re-sources from `WHERE waiting_for IS NOT NULL` plus the standard
+  actionable filters. Lands as PR H.
 
 ### 4.6 Permissive direct edges — **OPEN**
 
@@ -234,7 +260,7 @@ The reason: the axes the FSM is trying to encode are genuinely orthogonal.
 |-----------------------------|-----------------------------------------------|----------------|
 | Has it been clarified?      | `state == 'inbox'`                            | boolean        |
 | Does the user want to do it?| `state == 'next_action'` vs `'someday_maybe'` | enum / intent  |
-| Is it complete?             | `state == 'done'` (and/or `completed`)        | timestamp      |
+| Is it complete?             | `state == 'done'` + `completed_at` timestamp  | timestamp (`done_at`, renamed from `completed_at`) |
 | What's blocking it?         | `state` ∈ {`waiting_for`, `scheduled`, `blocked`} + `blocked_by_todo_id`, `waiting_for` text | list of blockers |
 | Is it on today's plan?      | `selected_for_today`                          | session-membership |
 | Is it the active task?      | `state == 'in_progress'`                      | session pointer + timer |
@@ -275,17 +301,39 @@ Blocker  (polymorphic — see §6.2 for nuance)
   LocationBlocker { place }                   # e.g. "fix garage door at home"
 
 FocusSession
-  id, started_at, ended_at
+  id:              UUID PK
+  user_id          (partial unique index WHERE ended_at IS NULL — at most
+                    one open session per user at any moment; see §7.1)
+  started_at, ended_at
   tasks:           List<TaskRef>              # locked at session start
   current_task_id: TaskRef?                   # the "in progress" pointer
 
 PeriodicSession                               # NOT a generalization of Focus
   (separate entity — see §6.1)
 
-Timer  (per FocusSession)
-  state:     {idle, running, paused}          # small local FSM — fine
-  intervals: List<{start, end}>               # appended on stop; sums to task.time_spent
+TimeLog                                       # one contiguous task-focus span
+  id, user_id, task_id, focus_session_id?
+  started_at, ended_at?                       # ended_at NULL = currently active
+  (partial unique index WHERE ended_at IS NULL — at most one open log per
+   user; mirrors the FocusSession invariant at the time-tracking layer)
+
+Timer  (per FocusSession — display-side construct)
+  state: {idle, running, paused}              # small local FSM, no DB rows
 ```
+
+**TimeLog framing (revised 2026-04-26).** A `TimeLog` row IS a (start, end)
+pair scoped to one task. A `FocusSession`'s "intervals" are simply its
+`TimeLog` rows. Switching focus from task A → B → A inside one session
+writes three rows. **Pauses do not split rows** — they are client-side
+cosmetic per the existing `focus_session_provider.dart:111-125` pattern;
+breaks count as work. **Pomodoro sprints do not write `TimeLog` rows
+either** — sprints are an orthogonal display loop on top of the running
+log; the existing `_logSprintTimeToTask` write path retires when `TimeLog`
+ships (otherwise it would double-count).
+
+Earlier drafts of this section described `Timer.intervals: List<{start,
+end}>` as a per-task, per-pause-split construct. That framing is
+superseded.
 
 Wins relative to the current FSM:
 
@@ -300,8 +348,12 @@ Wins relative to the current FSM:
 - **Day-boundary date arithmetic disappears.** `FocusSession` owns its own
   `started_at`/`ended_at`; "today" is UI copy. The bug class flagged in the
   `project_day_boundary` memory is structurally impossible.
-- **Polymorphic blockers** subsume `waiting_for`, `scheduled`, and `blocked`
-  with cleaner semantics — including multiple simultaneous blockers (§6.2).
+- **Polymorphic blockers** *will* subsume `waiting_for`, `scheduled`, and
+  `blocked` with cleaner semantics — including multiple simultaneous blockers
+  (§6.2). The rollout (§4.5 sibling decisions, 2026-04-26) strips those
+  blocker-flavoured states *first* and lets the polymorphic-blocker epic
+  (TMaYaD/Jeeves#181) reintroduce them later — alpha tolerates the lossy
+  middle.
 - **Ritual-bypass methods retire** because the FSM they were bypassing no
   longer exists.
 
@@ -505,26 +557,97 @@ Independently:
 
 ---
 
+## 7.1 FocusSession PK and uniqueness (decided 2026-04-26)
+
+```text
+focus_sessions
+  id          UUID PRIMARY KEY
+  user_id     UUID NOT NULL
+  started_at  TIMESTAMPTZ NOT NULL
+  ended_at    TIMESTAMPTZ NULL
+  current_task_id UUID NULL  REFERENCES todos(id)
+
+  CREATE UNIQUE INDEX focus_sessions_one_open_per_user
+    ON focus_sessions(user_id) WHERE ended_at IS NULL;
+
+focus_session_tasks
+  focus_session_id UUID NOT NULL REFERENCES focus_sessions(id)
+  task_id          UUID NOT NULL REFERENCES todos(id)
+  position         INT  NOT NULL
+  PRIMARY KEY (focus_session_id, task_id)
+```
+
+**Why this shape.**
+
+- Many sessions per user over time, exactly one open at any moment. The
+  partial unique index enforces structurally what the FSM enforced
+  imperatively ("at most one in-progress task").
+- Multiple task-focus spans per session (`focus_session_tasks` membership) and
+  multiple sessions per day are both supported.
+- Session lifecycle is owned by `started_at` / `ended_at`; "today" is UI
+  copy. The day-boundary bug class flagged in the `project_day_boundary`
+  memory is structurally impossible.
+
+## 7.2 `Intent` enum is 3-value at the column level (decided 2026-04-26)
+
+```text
+intent ∈ {next, maybe, trash}
+```
+
+`'trash'` is included in the column domain from PR E (the strip-someday PR
+that introduces the column). UI surfaces only `next` and `maybe` for now;
+the `trash` UX is a separate design.
+
+The lossy alternative — landing the column 2-valued and altering it to
+3-valued later — would force a second migration and a brittle
+column-with-shifting-domain. Cheaper to land the final domain on day one and
+gate the third value behind UI.
+
+---
+
 ## 8. Open questions
 
-These are *not* decided:
+Still *not* decided:
 
 1. **Projects vs. TaskBlockers.** Does the model need a first-class Project
    entity? If yes, how heavy? If no, how do we handle non-trivial
-   dependency chains?
+   dependency chains? *(Owned by TMaYaD/Jeeves#181 — polymorphic blockers
+   epic.)*
 2. **Recurring-window TimeBlockers.** Schema and evaluation strategy. RRULE
-   subset vs. our own enum vs. cron-like syntax.
+   subset vs. our own enum vs. cron-like syntax. *(Owned by
+   TMaYaD/Jeeves#181.)*
 3. **Permissiveness of intent transitions.** Should the model enforce
    ritual-gated changes (e.g. "you can only move a task from `next` to
    `maybe` during a periodic session"), or allow ad-hoc edits anytime? The
-   current FSM is lax; the reference FSM was strict.
+   current FSM is lax; the reference FSM was strict. *(Picked up after the
+   FSM strip lands; the rollout treats `intent` as a free-edit field for
+   now.)*
 4. **Lifecycle of `clarified=false` Inbox items.** Same row as Task or
-   separate `InboxItem` entity? Affects future split/merge UX.
-5. **Multiple FocusSessions per day.** Allowed? Probably yes — morning
-   session, afternoon session — but UX implications for "rollover" need a
-   pass.
-6. **Migration plan.** Phased path from current FSM to proposed model. Not
-   yet specified.
+   separate `InboxItem` entity? Affects future split/merge UX. *(Owned by
+   TMaYaD/Jeeves#184 — Clarify & Organise rework. The PR F strip keeps
+   `clarified` as a Task column treated as an internal detail per §6.4 so
+   this remains reversible.)*
+
+Resolved since the original draft (2026-04-26 rollout planning — full
+record in `docs/proposals/task-model-rollout.md`):
+
+- ~~5. Multiple FocusSessions per day.~~ **Decided yes.** A user may open and
+  close arbitrarily many sessions in a calendar day; the partial unique
+  index in §7.1 only forbids two *open* sessions concurrently.
+- ~~6. Migration plan.~~ **Decided.** Eleven-PR phased rollout (PRs A–K) in
+  `docs/proposals/task-model-rollout.md`. Each PR is a full-stack atomic
+  vertical slice; the `state` column shrinks one allowed value per PR and
+  drops in PR J.
+- **Intent enum domain.** `{next, maybe, trash}` at the column level from
+  PR E (§7.2). UI surfaces only `next` / `maybe`.
+- **Done timestamp.** `completed_at` is *renamed* to `done_at` in PR G, not
+  parallel-added — same semantics, one fewer column to retire later.
+- **TimeLog backfill.** None. PR D treats `time_spent_minutes` as a frozen
+  cache for pre-existing time; new time logs through `TimeLog` and updates
+  the cache. The cache may be inconsistent for tasks with both pre- and
+  post-cutover time; that is acceptable in alpha and instrumentation later
+  decides whether to drop the cache and switch to live `SUM(TimeLog)`
+  reads.
 
 ---
 
@@ -543,6 +666,40 @@ discussion as committed (subject to written-down rebuttal):
 - Internal terminology drops "Daily" and "Evening" in favour of
   session-relative names; UI copy retains user-facing "today" / "this week"
   language (§10).
+
+### 9.1 Rollout-planning decisions (2026-04-26)
+
+A separate session locked the *rollout* shape — how the proposal lands as a
+sequence of mergeable PRs. Detailed plan in
+`docs/proposals/task-model-rollout.md`. The technical decisions (the ones
+that constrain the *model*, not just the rollout sequence) are captured
+inline in §4.5, §6, §7.1, §7.2, and §8 above. Summarised here for
+convenience:
+
+- **Each PR is a full-stack atomic vertical slice** (schema + DAO + UI +
+  tests for one concept), landing **sequentially**, not in parallel.
+- **No feature flags, no FSM↔FocusSession coexistence period.** Backwards-
+  compat shims and deprecated-column shadows are out of scope. The codebase
+  moves forward in lockstep — alpha tolerates this.
+- **The `state` column shrinks one allowed value per PR**, then drops in
+  PR J when only `next_action` is left. No big-bang migration.
+- **Polymorphic blockers (TMaYaD/Jeeves#181) are not a prerequisite.**
+  `scheduled` / `blocked` / `waiting_for` strip first (§4.5); blockers
+  reintroduce later. Lossy on `blocked_by_todo_id` — accepted in alpha.
+- **TimeLog (PR D) ships without `focus_session_id`**; the FK is added in
+  PR I when `FocusSession` exists.
+- **A `TimeLog` row is one contiguous task-focus span.** Pauses are
+  cosmetic and do not split rows; Pomodoro sprints do not write `TimeLog`
+  rows (§6 revised framing). The existing `_logSprintTimeToTask` write
+  path retires when PR D ships.
+- **`completed_at` is renamed to `done_at` in PR G**, not parallel-added.
+- **`time_spent_minutes` is kept as a denormalized cache** of `SUM(TimeLog)`
+  with no historical backfill. Drop decision deferred to instrumentation.
+- **PR I's UI scope is "wire, don't rewrite."** The new ritual UX from
+  TMaYaD/Jeeves#180 is out of scope for PR I — PR I threads the existing
+  screens through `FocusSessionDao` and removes more LoC than it adds.
+- **PR #140 (Evening Shutdown) is held**; salvage-or-rewrite decided after
+  PR I lands. The session-review wrap-up flow is PR K.
 
 ---
 


### PR DESCRIPTION
## Summary

- Updates `docs/proposals/task-model.md` with the 14 decisions locked in the 2026-04-26 rollout-planning session — mirrored into §4.5 (sibling state evaporations), §6 (TimeLog framing revised — pauses don't split rows; Pomodoro doesn't write rows), §7.1 (FocusSession PK + partial unique index), §7.2 (3-value `intent` enum at column level day one), §8 (resolved questions marked), §9.1 (rollout decisions summary).
- Adds `docs/proposals/task-model-rollout.md` — the PR-by-PR rollout plan: 11 sequential vertical-slice PRs (A–K) decomposing TMaYaD/Jeeves#185.

## What this is and isn't

- This is the **planning doc** that gates issue creation for PRs A–K. No code in this PR.
- It locks rollout-shape decisions but doesn't reopen domain decisions. Open §8 questions remain open (projects vs TaskBlockers, recurring-window TimeBlockers, intent-edit permissiveness, InboxItem entity).

## Key calls captured

- **Eleven sequential vertical-slice PRs**, no parallelism, no feature flags. State column shrinks one allowed value per PR; FocusSession lands in a single load-bearing PR I.
- **Polymorphic blockers (TMaYaD/Jeeves#181) is NOT a prerequisite.** `scheduled` / `blocked` / `waiting_for` strip first; `blocked_by_todo_id` is dropped (lossy, alpha-acceptable).
- **TimeLog (TMaYaD/Jeeves#182, PR D) ships without `focus_session_id`** — added in PR I when FocusSession exists.
- **Pomodoro stops writing time directly.** `_logSprintTimeToTask` retires in PR D.
- **`completed_at` is renamed to `done_at`** in PR G — not parallel-added.
- **`intent` enum is 3-value at the column level day one** (`{next, maybe, trash}`); UI surfaces `next` + `maybe` only.
- **PR I scope is "wire, don't rewrite."** New ritual UX (TMaYaD/Jeeves#180) is out of scope; PR I removes more LoC than it adds.

## Test plan

- [ ] Read `docs/proposals/task-model.md` end-to-end; verify §4.5 / §6 / §7.1 / §7.2 / §8 / §9.1 read coherently with the new decisions.
- [ ] Read `docs/proposals/task-model-rollout.md` end-to-end; verify per-PR scope, gotchas, and ordering match expectations.
- [ ] Decide whether the rollout doc should also link from `docs/ARCHITECTURE.md`.

Tracks TMaYaD/Jeeves#185.