### PR TITLE
Enforce User Story / Scope / Acceptance Criteria issue format

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,54 @@
+name: Feature / Task
+description: Standard issue format — user story, scope, acceptance criteria.
+title: "Short, imperative summary of the change"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for all new issues (features, bugs, refactors, infra).
+        See #58 for a worked example. Fill out every section — sections left blank
+        will block triage.
+  - type: textarea
+    id: user-story
+    attributes:
+      label: User Story
+      description: "Format: As a <persona>, I want <capability>, so I can <outcome>."
+      placeholder: "As a mobile user, I want to share text from any app to my inbox, so I can capture tasks without opening the app."
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: Bullet list of what is in scope. Keep it concrete and bounded.
+      placeholder: |
+        - Register app as Android Share Sheet target
+        - Accept text, URLs, and image attachments
+        - Create inbox item with shared content as title/notes
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: Checkbox list of testable conditions. Each box must be independently verifiable.
+      value: |
+        - [ ]
+        - [ ]
+        - [ ]
+    validations:
+      required: true
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: Out of Scope (optional)
+      description: Anything explicitly NOT covered by this issue. Helps prevent scope creep.
+    validations:
+      required: false
+  - type: textarea
+    id: related
+    attributes:
+      label: Related (optional)
+      description: Linked issues, PRs, docs, or proposals.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -32,10 +32,9 @@ body:
     attributes:
       label: Acceptance Criteria
       description: Checkbox list of testable conditions. Each box must be independently verifiable.
-      value: |
-        - [ ]
-        - [ ]
-        - [ ]
+      placeholder: |
+        - [ ] First testable condition
+        - [ ] Second testable condition
     validations:
       required: true
   - type: textarea

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,25 @@ Strictly follow Semantic Versioning.
 5. **Verify** - Full test suite, build check
 6. **Update scratchpad** - Mark goal done, set next goal
 
+## Creating GitHub Issues
+
+All issues must follow the project's issue template (`.github/ISSUE_TEMPLATE/`).
+The GitHub UI enforces this on humans; agents creating issues via the API must
+match it manually.
+
+Required sections, in order:
+
+- **User Story** — `As a <persona>, I want <capability>, so I can <outcome>.`
+- **Scope** — bullet list of what's in scope.
+- **Acceptance Criteria** — checkbox list of testable conditions.
+
+Optional sections (include when they add value):
+
+- **Out of Scope** — what is explicitly NOT covered.
+- **Related** — linked issues, PRs, docs, proposals.
+
+Do not open issues that skip the required sections.
+
 ## Scratchpad (`SCRATCHPAD.md`)
 
 Maintain a scratchpad with:


### PR DESCRIPTION
## Summary

- Add a GitHub issue form (`.github/ISSUE_TEMPLATE/feature.yml`) modelled on #58 — required sections: **User Story**, **Scope**, **Acceptance Criteria**; optional: **Out of Scope**, **Related**.
- Disable blank issues (`.github/ISSUE_TEMPLATE/config.yml`) so the form is the only path through the UI.
- Add a "Creating GitHub Issues" section to `AGENTS.md` so agents creating issues via the API match the same format humans get from the UI.

## Test plan

- [ ] Open https://github.com/TMaYaD/Jeeves/issues/new — only the "Feature / Task" template is offered (blank issue path is gone).
- [ ] User Story / Scope / Acceptance Criteria fields are marked required and block submission when empty.
- [ ] Reread `AGENTS.md` — the new section appears between "Workflow" and "Scratchpad" and lists the required sections in order.

## Notes

- AGENTS.md is the project's "generic, copy-pasteable" doc, so the new section references the conventional `.github/ISSUE_TEMPLATE/` path rather than a specific file or issue number.
- The existing repo has two issue shapes in the wild: feature/story (e.g. #58) and problem/fix (e.g. #289, #292, #293). This PR standardises on the #58 shape per the request. If a separate "Bug / Refactor" template is wanted later, add it as a second YAML file alongside this one.


---
_Generated by [Claude Code](https://claude.ai/code/session_01P2samnuW1W8xySyjE4myyN)_