### PR TITLE
fix(sync): persist user_preferences across devices

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,5 +1,10 @@
 # Notes
 
+## 2026-05-17 (branch `claude/fix-banner-persistence-rzQsa`)
+- `user_preferences` had no REST upload route on the backend and no case in `JevesBackendConnector.uploadData`'s switch. The `default:` branch was a silent `debugPrint`, so the CRUD entry fell through to `batch.complete()` and was deleted from the local queue without ever talking to the server. Next sync pull then reconciled the row away because the server had no record. End result: any local-only `user_preferences` write (e.g. a banner dismissal, `last_completed`) vanished on the first online round-trip. Fix: add `POST/PATCH/DELETE /user_preferences/`, add the connector case, and turn `default:` into a `throw StateError` so future Synced tables can't repeat the same data-loss footgun silently.
+- The `_isFatal` 4xx-drop behaviour in the connector is dormant for the current bug — no handler ran today, so no `DioException` was ever thrown. It becomes a live data-loss risk the moment any handler can hit a 4xx (e.g. the new `user_preferences` route returning 409 on `(user_id, key)` collisions). Tracked separately as #305; out of scope here.
+- Reconciliation when local row exists but server snapshot omits it is the read-side mirror of this bug and is **not** covered by adding the upload route — see #306. The right resolution likely differs per `user_preferences` key (LWW vs set-merge vs hold-until-acked); audit needed.
+
 ## 2026-05-15 (issue #247)
 - Multi-select on Step 3 (Review Next Actions) lives in widget-local state on `PlanSummaryStep`; no provider/DAO change. `selectTask(id)` is already idempotent and "Add to Today" simply loops it. The committable set is filtered against the current pending snapshot so a row deleted between selection and commit can't be falsely reported as added.
 - The contextual multi-select bar is rendered **inside** `PlanSummaryStep`, above the scrollable list — not in the screen-level app bar. The app bar slot is owned by `FocusSessionPlanningScreen` and is busy with step progress + title; reusing it would mean either hiding step state or fighting the planning header layout.

--- a/app/lib/services/backend_connector.dart
+++ b/app/lib/services/backend_connector.dart
@@ -44,9 +44,14 @@ class JevesBackendConnector extends ps.PowerSyncBackendConnector {
   /// Upload locally-queued writes to the backend REST API.
   ///
   /// Each CRUD entry maps to the corresponding REST endpoint:
-  ///   - todos:     POST /todos/,       PATCH /todos/{id},      DELETE /todos/{id}
-  ///   - tags:      POST /tags/,        PATCH /tags/{id},       DELETE /tags/{id}
-  ///   - todo_tags: POST /todo_tags/,                           DELETE /todo_tags/{id}
+  ///   - todos:             POST /todos/,             PATCH /todos/{id},             DELETE /todos/{id}
+  ///   - tags:              POST /tags/,              PATCH /tags/{id},              DELETE /tags/{id}
+  ///   - todo_tags:         POST /todo_tags/,                                        DELETE /todo_tags/{id}
+  ///   - user_preferences:  POST /user_preferences/,  PATCH /user_preferences/{id},  DELETE /user_preferences/{id}
+  ///
+  /// Unknown tables must throw — otherwise `batch.complete()` would clear
+  /// the local CRUD queue without ever talking to the server, silently
+  /// losing the user's offline writes.
   ///
   /// Errors are classified per-entry so one bad row doesn't poison the batch:
   ///   - 4xx (except 401) is fatal for THAT entry — log it and skip; the
@@ -68,9 +73,13 @@ class JevesBackendConnector extends ps.PowerSyncBackendConnector {
             await _uploadTag(entry);
           case 'todo_tags':
             await _uploadTodoTag(entry);
+          case 'user_preferences':
+            await _uploadUserPreference(entry);
           default:
-            debugPrint(
-              'JevesBackendConnector: unhandled table ${entry.table}',
+            throw StateError(
+              'JevesBackendConnector: no upload handler for table '
+              '"${entry.table}". Add a case to uploadData() or rows on '
+              'this table will be silently lost from the CRUD queue.',
             );
         }
       } on DioException catch (e) {
@@ -126,6 +135,19 @@ class JevesBackendConnector extends ps.PowerSyncBackendConnector {
         break;
       case ps.UpdateType.delete:
         await _api.delete('/todo_tags/${entry.id}');
+    }
+  }
+
+  Future<void> _uploadUserPreference(ps.CrudEntry entry) async {
+    switch (entry.op) {
+      case ps.UpdateType.put:
+        final body = Map<String, dynamic>.from(entry.opData ?? {});
+        body['id'] = entry.id;
+        await _api.post('/user_preferences/', body);
+      case ps.UpdateType.patch:
+        await _api.patch('/user_preferences/${entry.id}', entry.opData ?? {});
+      case ps.UpdateType.delete:
+        await _api.delete('/user_preferences/${entry.id}');
     }
   }
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,6 +15,7 @@ from app.health.routes import router as health_router
 from app.powersync.routes import router as powersync_router
 from app.todos.routes import router as todo_router
 from app.todos.tag_routes import router as tag_router
+from app.todos.user_preference_routes import router as user_preference_router
 
 
 @asynccontextmanager
@@ -43,5 +44,6 @@ app.include_router(health_router)
 app.include_router(auth_router)
 app.include_router(todo_router)
 app.include_router(tag_router, tags=["tags"])
+app.include_router(user_preference_router, tags=["user_preferences"])
 app.include_router(ai_router)
 app.include_router(powersync_router, prefix="/powersync", tags=["powersync"])

--- a/backend/app/todos/schemas.py
+++ b/backend/app/todos/schemas.py
@@ -174,6 +174,34 @@ class TagOut(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class UserPreferenceCreate(BaseModel):
+    id: str | None = None  # Client-side UUID for idempotency
+    key: str
+    value: str | None = None
+    updated_at: datetime
+
+    _normalise_updated_at = field_validator("updated_at", mode="before")(_normalise_drift_iso)
+
+
+class UserPreferenceUpdate(BaseModel):
+    # Both fields are optional in the schema but the connector always sends
+    # `updated_at` alongside any `value` change so LWW arbitration has a
+    # truthful timestamp.
+    value: str | None = None
+    updated_at: datetime | None = None
+
+    _normalise_updated_at = field_validator("updated_at", mode="before")(_normalise_drift_iso)
+
+
+class UserPreferenceOut(BaseModel):
+    id: str
+    key: str
+    value: str | None
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
 class TimeLogOut(BaseModel):
     id: str
     user_id: str

--- a/backend/app/todos/user_preference_routes.py
+++ b/backend/app/todos/user_preference_routes.py
@@ -1,0 +1,85 @@
+"""Standalone CRUD for `user_preferences`.
+
+Called by the PowerSync BackendConnector to upload offline writes to the
+synced key-value preference store. Conflict resolution between local and
+server rows is out of scope here (see issue #306); these endpoints just
+apply the client's authoritative intent for rows it owns.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.dependencies import get_current_user
+from app.auth.models import User
+from app.database import get_db
+from app.todos.models import UserPreference
+from app.todos.schemas import (
+    UserPreferenceCreate,
+    UserPreferenceOut,
+    UserPreferenceUpdate,
+)
+
+router = APIRouter()
+
+
+@router.post(
+    "/user_preferences/",
+    response_model=UserPreferenceOut,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_user_preference(
+    body: UserPreferenceCreate,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> UserPreference:
+    # Idempotency: if the client-generated id already exists for this user,
+    # return it. PowerSync re-uploads the same CRUD entry on retry; we must
+    # not 409 the second attempt.
+    if body.id is not None:
+        existing = await db.get(UserPreference, body.id)
+        if existing is not None:
+            if existing.user_id == current_user.id:
+                return existing
+            raise HTTPException(status_code=409, detail="Preference id already exists")
+
+    pref = UserPreference(
+        **({"id": body.id} if body.id is not None else {}),
+        user_id=current_user.id,
+        key=body.key,
+        value=body.value,
+        updated_at=body.updated_at,
+    )
+    db.add(pref)
+    await db.commit()
+    await db.refresh(pref)
+    return pref
+
+
+@router.patch("/user_preferences/{pref_id}", response_model=UserPreferenceOut)
+async def update_user_preference(
+    pref_id: str,
+    body: UserPreferenceUpdate,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> UserPreference:
+    pref = await db.get(UserPreference, pref_id)
+    if pref is None or pref.user_id != current_user.id:
+        raise HTTPException(status_code=404, detail="Preference not found")
+    for field, value in body.model_dump(exclude_unset=True).items():
+        setattr(pref, field, value)
+    await db.commit()
+    await db.refresh(pref)
+    return pref
+
+
+@router.delete("/user_preferences/{pref_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_user_preference(
+    pref_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> None:
+    pref = await db.get(UserPreference, pref_id)
+    if pref is None or pref.user_id != current_user.id:
+        raise HTTPException(status_code=404, detail="Preference not found")
+    await db.delete(pref)
+    await db.commit()

--- a/backend/tests/test_user_preferences.py
+++ b/backend/tests/test_user_preferences.py
@@ -1,0 +1,190 @@
+"""REST CRUD for `user_preferences`, called by the PowerSync BackendConnector.
+
+These tests exercise the upload-side path that the mobile client uses to
+persist offline writes to the `user_preferences` table. Reconciliation /
+conflict semantics are covered separately (see issue #306).
+"""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.todos.models import UserPreference
+from tests.conftest import auth_header, register
+
+
+@pytest.mark.asyncio
+async def test_create_requires_auth(client: AsyncClient) -> None:
+    resp = await client.post(
+        "/user_preferences/",
+        json={
+            "key": "last_completed",
+            "value": '"2026-05-17T00:00:00Z"',
+            "updated_at": "2026-05-17T00:00:00Z",
+        },
+    )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_create_persists_row(client: AsyncClient, db: AsyncSession) -> None:
+    token = await register(client, "pref-create@example.com")
+    resp = await client.post(
+        "/user_preferences/",
+        json={
+            "id": "11111111-1111-1111-1111-111111111111",
+            "key": "last_completed",
+            "value": '"2026-05-17T10:00:00Z"',
+            "updated_at": "2026-05-17T10:00:00Z",
+        },
+        headers=auth_header(token),
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["id"] == "11111111-1111-1111-1111-111111111111"
+    assert body["key"] == "last_completed"
+    assert body["value"] == '"2026-05-17T10:00:00Z"'
+
+    row = (
+        await db.execute(select(UserPreference).where(UserPreference.id == body["id"]))
+    ).scalar_one()
+    assert row.key == "last_completed"
+    assert row.value == '"2026-05-17T10:00:00Z"'
+
+
+@pytest.mark.asyncio
+async def test_create_is_idempotent_on_same_id(client: AsyncClient) -> None:
+    """PowerSync may re-upload the same CRUD entry; second POST must not error."""
+    token = await register(client, "pref-idem@example.com")
+    payload = {
+        "id": "22222222-2222-2222-2222-222222222222",
+        "key": "last_completed",
+        "value": '"v1"',
+        "updated_at": "2026-05-17T10:00:00Z",
+    }
+    first = await client.post("/user_preferences/", json=payload, headers=auth_header(token))
+    assert first.status_code == 201
+
+    second = await client.post("/user_preferences/", json=payload, headers=auth_header(token))
+    assert second.status_code == 201
+    assert second.json()["id"] == payload["id"]
+
+
+@pytest.mark.asyncio
+async def test_patch_updates_value_and_timestamp(client: AsyncClient, db: AsyncSession) -> None:
+    token = await register(client, "pref-patch@example.com")
+    pref_id = "33333333-3333-3333-3333-333333333333"
+    await client.post(
+        "/user_preferences/",
+        json={
+            "id": pref_id,
+            "key": "last_completed",
+            "value": '"v1"',
+            "updated_at": "2026-05-17T10:00:00Z",
+        },
+        headers=auth_header(token),
+    )
+
+    resp = await client.patch(
+        f"/user_preferences/{pref_id}",
+        json={"value": '"v2"', "updated_at": "2026-05-17T11:00:00Z"},
+        headers=auth_header(token),
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["value"] == '"v2"'
+
+    row = (
+        await db.execute(select(UserPreference).where(UserPreference.id == pref_id))
+    ).scalar_one()
+    assert row.value == '"v2"'
+
+
+@pytest.mark.asyncio
+async def test_patch_can_tombstone_with_null_value(client: AsyncClient) -> None:
+    """A patch with value=null is the tombstone path the DAO uses for deletes."""
+    token = await register(client, "pref-tombstone@example.com")
+    pref_id = "44444444-4444-4444-4444-444444444444"
+    await client.post(
+        "/user_preferences/",
+        json={
+            "id": pref_id,
+            "key": "last_completed",
+            "value": '"v1"',
+            "updated_at": "2026-05-17T10:00:00Z",
+        },
+        headers=auth_header(token),
+    )
+
+    resp = await client.patch(
+        f"/user_preferences/{pref_id}",
+        json={"value": None, "updated_at": "2026-05-17T12:00:00Z"},
+        headers=auth_header(token),
+    )
+    assert resp.status_code == 200
+    assert resp.json()["value"] is None
+
+
+@pytest.mark.asyncio
+async def test_delete_removes_row(client: AsyncClient, db: AsyncSession) -> None:
+    token = await register(client, "pref-delete@example.com")
+    pref_id = "55555555-5555-5555-5555-555555555555"
+    await client.post(
+        "/user_preferences/",
+        json={
+            "id": pref_id,
+            "key": "last_completed",
+            "value": '"v1"',
+            "updated_at": "2026-05-17T10:00:00Z",
+        },
+        headers=auth_header(token),
+    )
+
+    resp = await client.delete(f"/user_preferences/{pref_id}", headers=auth_header(token))
+    assert resp.status_code == 204
+
+    row = (
+        await db.execute(select(UserPreference).where(UserPreference.id == pref_id))
+    ).scalar_one_or_none()
+    assert row is None
+
+
+@pytest.mark.asyncio
+async def test_user_isolation(client: AsyncClient) -> None:
+    """User A cannot patch or delete user B's preference rows."""
+    token_a = await register(client, "pref-alice@example.com")
+    token_b = await register(client, "pref-bob@example.com")
+    pref_id = "66666666-6666-6666-6666-666666666666"
+
+    create = await client.post(
+        "/user_preferences/",
+        json={
+            "id": pref_id,
+            "key": "last_completed",
+            "value": '"alice"',
+            "updated_at": "2026-05-17T10:00:00Z",
+        },
+        headers=auth_header(token_a),
+    )
+    assert create.status_code == 201
+
+    bob_patch = await client.patch(
+        f"/user_preferences/{pref_id}",
+        json={"value": '"bob"', "updated_at": "2026-05-17T11:00:00Z"},
+        headers=auth_header(token_b),
+    )
+    assert bob_patch.status_code == 404
+
+    bob_delete = await client.delete(f"/user_preferences/{pref_id}", headers=auth_header(token_b))
+    assert bob_delete.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_patch_missing_row_returns_404(client: AsyncClient) -> None:
+    token = await register(client, "pref-missing@example.com")
+    resp = await client.patch(
+        "/user_preferences/77777777-7777-7777-7777-777777777777",
+        json={"value": '"v1"', "updated_at": "2026-05-17T10:00:00Z"},
+        headers=auth_header(token),
+    )
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary

Local writes to `user_preferences` (banner dismissals, `last_completed`, focus settings, planning toggles) were silently lost on the first online round-trip. Three changes, all required together to close the loop:

- **Backend**: add `POST/PATCH/DELETE /user_preferences/` REST endpoints. `POST` is idempotent on the client-generated UUID so PowerSync retries are safe; `PATCH`/`DELETE` check ownership via the JWT user.
- **Connector**: add the `user_preferences` case to `JevesBackendConnector.uploadData` with `put`/`patch`/`delete` handlers mirroring `_uploadTodo` / `_uploadTag`.
- **Connector**: turn the `switch` `default:` branch from a silent `debugPrint` into a `throw StateError`. The silent branch is what made this bug a data-loss bug: without a handler the entry fell through, `batch.complete()` cleared it from the local CRUD queue, and the next pull reconciled the absent server row by deleting the local one. Making `default:` loud means any future Synced Drift table missing a handler fails at dev time instead of nuking user data in production.

## Root cause

1. User toggles a preference → DAO writes row + queues CRUD entry.
2. `uploadData` runs → `switch` falls into `default:` → `debugPrint` only, no HTTP call.
3. `batch.complete()` removes the entry from the queue.
4. Next pull → server has no row → reconciliation deletes the local row.
5. UI re-renders the "never" state.

The 4xx-fatal path in `_isFatal` was never involved — no HTTP request was ever made for `user_preferences`. That's a related-but-orthogonal hazard (filed as #305).

## Out of scope

- **Conflict resolution** between local and server `user_preferences` rows when both exist or local-only-vs-server-absent — see #306. That issue calls for a per-key audit (LWW for timestamps and flags, set-merge for list-shaped prefs, hold-until-ack for high-stakes ones). This PR makes the upload route exist; #306 decides what the read path should do with it.
- **4xx-fatal drop behaviour** in `BackendConnector._isFatal` — see #305. Today the connector blanket-drops every 4xx (except 401/429), which becomes a live data-loss risk now that real handlers exist for `user_preferences`.

## Test plan

- [x] `backend/tests/test_user_preferences.py` — 8 new tests covering auth, create-persists, idempotent POST, PATCH update, PATCH-to-tombstone (null value), DELETE, cross-user isolation, missing-row → 404.
- [x] Full backend test suite green: 99/99 passing.
- [x] `ruff check`, `ruff format`, `mypy` clean on new files.
- [ ] **Manual emulator check** — connector compilation + a round-trip "dismiss banner → kill app → relaunch → banner stays dismissed" run. Could not run `dart analyze` / `flutter test` in this remote environment (toolchain not installed); needs CI / local verification.

## Related

- Closes the data-loss path for `user_preferences` writes.
- Spin-offs: #305 (4xx-fatal drop), #306 (per-key conflict resolution).

https://claude.ai/code/session_018pRPjTEj1TE4wq4Ux2EeWy

---
_Generated by [Claude Code](https://claude.ai/code/session_018pRPjTEj1TE4wq4Ux2EeWy)_