### PR TITLE
fix(banners): suppress daily planning banner while weekly review banner is visible

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -244,3 +244,6 @@
 
 ## 2026-05-15 (issue #294)
 - `ProcessAction.reclarify` is a button (renders its own row, like `keep`) — distinct from `nextActionDialog`, which is a button-modifier. Sub-flow back-out maps to `ProcessAction.keep` so the review steps' existing "advance without recording" branch handles both back-outs and explicit Keeps with one path. `ClarifyMode.reclarify` guards the title-as-action mirror (write `next_action_text` only when the existing one is empty) so a re-clarification touch never clobbers a deliberately written phrase.
+
+## 2026-05-18
+- `periodicReviewBannerVisibleProvider` consolidates the weekly banner's visibility predicate so `FocusSessionPlanningBanner` can yield the slot by watching one provider — keeps the precedence rule (REQUIREMENTS.md §Daily Planning Entry) from drifting between the two widgets.

--- a/app/lib/providers/periodic_review_settings_provider.dart
+++ b/app/lib/providers/periodic_review_settings_provider.dart
@@ -142,31 +142,23 @@ final periodicReviewBannerEnabledProvider = Provider<bool>((ref) {
 
 /// True when the Weekly Review banner would render given current state.
 ///
-/// Single source of truth for the visibility predicate — both
-/// `PeriodicReviewBanner` and the daily `FocusSessionPlanningBanner`
-/// watch this provider (the daily banner uses it to yield the slot so the
-/// two never stack).
-///
-/// All eight dependencies are watched unconditionally — the obvious
-/// early-return shape (skipping the list watches when `isDue` is true)
-/// changes the dependency graph between `isDue==true` and `isDue==false`
-/// frames, which leaves widget tests with steady-state values that the
-/// inline predicate had already settled. Watching everything every time
-/// keeps the rebuild semantics identical to the original inline build.
+/// Mirrors the visibility predicate in `PeriodicReviewBanner` so other UI
+/// (notably the daily focus-session-planning banner) can suppress itself
+/// while the weekly banner is occupying the slot — preventing both banners
+/// from stacking when the weekly review is due.
 final periodicReviewBannerVisibleProvider = Provider<bool>((ref) {
-  final enabled = ref.watch(periodicReviewBannerEnabledProvider);
-  final dismissed = ref.watch(periodicReviewBannerDismissedTodayProvider);
+  if (!ref.watch(periodicReviewBannerEnabledProvider)) return false;
+  if (ref.watch(periodicReviewBannerDismissedTodayProvider)) return false;
+
   final hasTodos = ref.watch(hasTodosProvider);
-  final isDue = ref.watch(periodicReviewIsDueProvider);
+  if (!hasTodos.hasValue || !hasTodos.requireValue) return false;
+
+  if (ref.watch(periodicReviewIsDueProvider)) return true;
+
   final inbox = ref.watch(unfilteredInboxProvider);
   final next = ref.watch(unfilteredNextActionsProvider);
   final waiting = ref.watch(unfilteredWaitingForProvider);
   final maybe = ref.watch(unfilteredMaybeProvider);
-
-  if (!enabled) return false;
-  if (dismissed) return false;
-  if (!hasTodos.hasValue || !hasTodos.requireValue) return false;
-  if (isDue) return true;
   if (!inbox.hasValue ||
       !next.hasValue ||
       !waiting.hasValue ||

--- a/app/lib/providers/periodic_review_settings_provider.dart
+++ b/app/lib/providers/periodic_review_settings_provider.dart
@@ -13,6 +13,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import '../services/notification_service.dart';
 import 'focus_session_planning_provider.dart' show planningToday;
+import 'gtd_lists_provider.dart';
+import 'onboarding_provider.dart';
 import 'synced_preferences_provider.dart';
 
 const _kLastCompletedAtKey = 'periodic_review_last_completed_at';
@@ -136,6 +138,36 @@ final periodicReviewBannerEnabledProvider = Provider<bool>((ref) {
           ?.value
           .get<bool>(_kBannerEnabledKey) ??
       true;
+});
+
+/// True when the Weekly Review banner would render given current state.
+///
+/// Mirrors the visibility predicate in `PeriodicReviewBanner` so other UI
+/// (notably the daily focus-session-planning banner) can suppress itself
+/// while the weekly banner is occupying the slot — preventing both banners
+/// from stacking when the weekly review is due.
+final periodicReviewBannerVisibleProvider = Provider<bool>((ref) {
+  if (!ref.watch(periodicReviewBannerEnabledProvider)) return false;
+  if (ref.watch(periodicReviewBannerDismissedTodayProvider)) return false;
+
+  final hasTodos = ref.watch(hasTodosProvider);
+  if (!hasTodos.hasValue || !hasTodos.requireValue) return false;
+
+  if (ref.watch(periodicReviewIsDueProvider)) return true;
+
+  final inbox = ref.watch(unfilteredInboxProvider);
+  final next = ref.watch(unfilteredNextActionsProvider);
+  final waiting = ref.watch(unfilteredWaitingForProvider);
+  final maybe = ref.watch(unfilteredMaybeProvider);
+  if (!inbox.hasValue ||
+      !next.hasValue ||
+      !waiting.hasValue ||
+      !maybe.hasValue) {
+    return false;
+  }
+  return inbox.requireValue.isEmpty &&
+      next.requireValue.isEmpty &&
+      (waiting.requireValue.isNotEmpty || maybe.requireValue.isNotEmpty);
 });
 
 // ---------------------------------------------------------------------------

--- a/app/lib/providers/periodic_review_settings_provider.dart
+++ b/app/lib/providers/periodic_review_settings_provider.dart
@@ -140,25 +140,25 @@ final periodicReviewBannerEnabledProvider = Provider<bool>((ref) {
       true;
 });
 
-/// True when the Weekly Review banner would render given current state.
-///
-/// Mirrors the visibility predicate in `PeriodicReviewBanner` so other UI
-/// (notably the daily focus-session-planning banner) can suppress itself
-/// while the weekly banner is occupying the slot — preventing both banners
-/// from stacking when the weekly review is due.
-final periodicReviewBannerVisibleProvider = Provider<bool>((ref) {
-  if (!ref.watch(periodicReviewBannerEnabledProvider)) return false;
-  if (ref.watch(periodicReviewBannerDismissedTodayProvider)) return false;
-
-  final hasTodos = ref.watch(hasTodosProvider);
+/// Single-source-of-truth predicate for "should the Weekly Review banner
+/// render?". Pure function so both `PeriodicReviewBanner` (which keeps
+/// its own inline `ref.watch` calls — changing that breaks its widget
+/// tests' pump timing) and the daily focus-session-planning banner (which
+/// reads it via [periodicReviewBannerVisibleProvider]) share one rule.
+bool computePeriodicReviewBannerVisible({
+  required bool enabled,
+  required bool dismissed,
+  required AsyncValue<bool> hasTodos,
+  required bool isDue,
+  required AsyncValue<List<Todo>> inbox,
+  required AsyncValue<List<Todo>> next,
+  required AsyncValue<List<Todo>> waiting,
+  required AsyncValue<List<Todo>> maybe,
+}) {
+  if (!enabled) return false;
+  if (dismissed) return false;
   if (!hasTodos.hasValue || !hasTodos.requireValue) return false;
-
-  if (ref.watch(periodicReviewIsDueProvider)) return true;
-
-  final inbox = ref.watch(unfilteredInboxProvider);
-  final next = ref.watch(unfilteredNextActionsProvider);
-  final waiting = ref.watch(unfilteredWaitingForProvider);
-  final maybe = ref.watch(unfilteredMaybeProvider);
+  if (isDue) return true;
   if (!inbox.hasValue ||
       !next.hasValue ||
       !waiting.hasValue ||
@@ -168,6 +168,22 @@ final periodicReviewBannerVisibleProvider = Provider<bool>((ref) {
   return inbox.requireValue.isEmpty &&
       next.requireValue.isEmpty &&
       (waiting.requireValue.isNotEmpty || maybe.requireValue.isNotEmpty);
+}
+
+/// True when the Weekly Review banner would render. Used by the daily
+/// focus-session-planning banner so it can yield the slot whenever the
+/// weekly banner is taking it — the two never stack.
+final periodicReviewBannerVisibleProvider = Provider<bool>((ref) {
+  return computePeriodicReviewBannerVisible(
+    enabled: ref.watch(periodicReviewBannerEnabledProvider),
+    dismissed: ref.watch(periodicReviewBannerDismissedTodayProvider),
+    hasTodos: ref.watch(hasTodosProvider),
+    isDue: ref.watch(periodicReviewIsDueProvider),
+    inbox: ref.watch(unfilteredInboxProvider),
+    next: ref.watch(unfilteredNextActionsProvider),
+    waiting: ref.watch(unfilteredWaitingForProvider),
+    maybe: ref.watch(unfilteredMaybeProvider),
+  );
 });
 
 // ---------------------------------------------------------------------------

--- a/app/lib/providers/periodic_review_settings_provider.dart
+++ b/app/lib/providers/periodic_review_settings_provider.dart
@@ -140,25 +140,22 @@ final periodicReviewBannerEnabledProvider = Provider<bool>((ref) {
       true;
 });
 
-/// Single-source-of-truth predicate for "should the Weekly Review banner
-/// render?". Pure function so both `PeriodicReviewBanner` (which keeps
-/// its own inline `ref.watch` calls — changing that breaks its widget
-/// tests' pump timing) and the daily focus-session-planning banner (which
-/// reads it via [periodicReviewBannerVisibleProvider]) share one rule.
-bool computePeriodicReviewBannerVisible({
-  required bool enabled,
-  required bool dismissed,
-  required AsyncValue<bool> hasTodos,
-  required bool isDue,
+/// The "empty actionable" leg of the Weekly Review banner predicate:
+/// true when inbox + next are both empty but waiting-for or maybe still
+/// hold items. Extracted so both `PeriodicReviewBanner` and
+/// [periodicReviewBannerVisibleProvider] share the same rule.
+///
+/// Stays as a pure function (over `AsyncValue`s) rather than as another
+/// Provider so callers can keep the original short-circuit order — the
+/// cheap `enabled` / `dismissed` / `hasTodos` watches must run before
+/// the list watches subscribe `unfilteredInboxProvider` et al., which
+/// pull in the full `databaseProvider` chain.
+bool emptyActionableBannerTrigger({
   required AsyncValue<List<Todo>> inbox,
   required AsyncValue<List<Todo>> next,
   required AsyncValue<List<Todo>> waiting,
   required AsyncValue<List<Todo>> maybe,
 }) {
-  if (!enabled) return false;
-  if (dismissed) return false;
-  if (!hasTodos.hasValue || !hasTodos.requireValue) return false;
-  if (isDue) return true;
   if (!inbox.hasValue ||
       !next.hasValue ||
       !waiting.hasValue ||
@@ -173,12 +170,20 @@ bool computePeriodicReviewBannerVisible({
 /// True when the Weekly Review banner would render. Used by the daily
 /// focus-session-planning banner so it can yield the slot whenever the
 /// weekly banner is taking it — the two never stack.
+///
+/// The cheap watches (`enabled`, `dismissed`, `hasTodos`) run before
+/// the list watches so callers gated off via `enabled=false` never pay
+/// the cost of subscribing to the database-backed list streams.
 final periodicReviewBannerVisibleProvider = Provider<bool>((ref) {
-  return computePeriodicReviewBannerVisible(
-    enabled: ref.watch(periodicReviewBannerEnabledProvider),
-    dismissed: ref.watch(periodicReviewBannerDismissedTodayProvider),
-    hasTodos: ref.watch(hasTodosProvider),
-    isDue: ref.watch(periodicReviewIsDueProvider),
+  if (!ref.watch(periodicReviewBannerEnabledProvider)) return false;
+  if (ref.watch(periodicReviewBannerDismissedTodayProvider)) return false;
+
+  final hasTodos = ref.watch(hasTodosProvider);
+  if (!hasTodos.hasValue || !hasTodos.requireValue) return false;
+
+  if (ref.watch(periodicReviewIsDueProvider)) return true;
+
+  return emptyActionableBannerTrigger(
     inbox: ref.watch(unfilteredInboxProvider),
     next: ref.watch(unfilteredNextActionsProvider),
     waiting: ref.watch(unfilteredWaitingForProvider),

--- a/app/lib/providers/periodic_review_settings_provider.dart
+++ b/app/lib/providers/periodic_review_settings_provider.dart
@@ -142,23 +142,31 @@ final periodicReviewBannerEnabledProvider = Provider<bool>((ref) {
 
 /// True when the Weekly Review banner would render given current state.
 ///
-/// Mirrors the visibility predicate in `PeriodicReviewBanner` so other UI
-/// (notably the daily focus-session-planning banner) can suppress itself
-/// while the weekly banner is occupying the slot — preventing both banners
-/// from stacking when the weekly review is due.
+/// Single source of truth for the visibility predicate — both
+/// `PeriodicReviewBanner` and the daily `FocusSessionPlanningBanner`
+/// watch this provider (the daily banner uses it to yield the slot so the
+/// two never stack).
+///
+/// All eight dependencies are watched unconditionally — the obvious
+/// early-return shape (skipping the list watches when `isDue` is true)
+/// changes the dependency graph between `isDue==true` and `isDue==false`
+/// frames, which leaves widget tests with steady-state values that the
+/// inline predicate had already settled. Watching everything every time
+/// keeps the rebuild semantics identical to the original inline build.
 final periodicReviewBannerVisibleProvider = Provider<bool>((ref) {
-  if (!ref.watch(periodicReviewBannerEnabledProvider)) return false;
-  if (ref.watch(periodicReviewBannerDismissedTodayProvider)) return false;
-
+  final enabled = ref.watch(periodicReviewBannerEnabledProvider);
+  final dismissed = ref.watch(periodicReviewBannerDismissedTodayProvider);
   final hasTodos = ref.watch(hasTodosProvider);
-  if (!hasTodos.hasValue || !hasTodos.requireValue) return false;
-
-  if (ref.watch(periodicReviewIsDueProvider)) return true;
-
+  final isDue = ref.watch(periodicReviewIsDueProvider);
   final inbox = ref.watch(unfilteredInboxProvider);
   final next = ref.watch(unfilteredNextActionsProvider);
   final waiting = ref.watch(unfilteredWaitingForProvider);
   final maybe = ref.watch(unfilteredMaybeProvider);
+
+  if (!enabled) return false;
+  if (dismissed) return false;
+  if (!hasTodos.hasValue || !hasTodos.requireValue) return false;
+  if (isDue) return true;
   if (!inbox.hasValue ||
       !next.hasValue ||
       !waiting.hasValue ||

--- a/app/lib/widgets/focus_session_planning_banner.dart
+++ b/app/lib/widgets/focus_session_planning_banner.dart
@@ -6,6 +6,7 @@ import '../providers/focus_session_planning_provider.dart';
 import '../providers/focus_session_planning_settings_provider.dart';
 import '../providers/gtd_lists_provider.dart';
 import '../providers/onboarding_provider.dart';
+import '../providers/periodic_review_settings_provider.dart';
 
 /// A dismissible banner shown at the top of shell views when the daily
 /// planning ritual is incomplete and the user hasn't dismissed it today.
@@ -66,6 +67,13 @@ class FocusSessionPlanningBanner extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final settings = ref.watch(focusSessionPlanningSettingsProvider);
     if (!settings.bannerEnabled) return const SizedBox.shrink();
+
+    // Yield the slot when the weekly review banner is taking it, so the two
+    // banners never stack. Re-evaluates automatically once the user dismisses
+    // the weekly banner or completes the review.
+    if (ref.watch(periodicReviewBannerVisibleProvider)) {
+      return const SizedBox.shrink();
+    }
 
     final hasTodos = ref.watch(hasTodosProvider);
     if (!hasTodos.hasValue) return const SizedBox.shrink();

--- a/app/lib/widgets/periodic_review_banner.dart
+++ b/app/lib/widgets/periodic_review_banner.dart
@@ -44,23 +44,36 @@ class PeriodicReviewBanner extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // Inline `ref.watch` calls (not via periodicReviewBannerVisibleProvider)
-    // keep the widget's rebuild dependency graph exactly as its existing
-    // tests were calibrated for — routing the eight watches through a
-    // derived Provider<bool> measurably changes pump-to-emission timing
-    // and was breaking the tests. The predicate itself is deduped via
-    // computePeriodicReviewBannerVisible.
-    final visible = computePeriodicReviewBannerVisible(
-      enabled: ref.watch(periodicReviewBannerEnabledProvider),
-      dismissed: ref.watch(periodicReviewBannerDismissedTodayProvider),
-      hasTodos: ref.watch(hasTodosProvider),
-      isDue: ref.watch(periodicReviewIsDueProvider),
-      inbox: ref.watch(unfilteredInboxProvider),
-      next: ref.watch(unfilteredNextActionsProvider),
-      waiting: ref.watch(unfilteredWaitingForProvider),
-      maybe: ref.watch(unfilteredMaybeProvider),
-    );
-    if (!visible) return const SizedBox.shrink();
+    // Cheap watches first — gating callers (e.g. tag_cloud_test) flip
+    // `periodicReviewBannerEnabledProvider` off to suppress this banner
+    // without overriding `databaseProvider`, so the list watches below
+    // must not run in that case.
+    if (!ref.watch(periodicReviewBannerEnabledProvider)) {
+      return const SizedBox.shrink();
+    }
+    if (ref.watch(periodicReviewBannerDismissedTodayProvider)) {
+      return const SizedBox.shrink();
+    }
+
+    final hasTodos = ref.watch(hasTodosProvider);
+    if (!hasTodos.hasValue || !hasTodos.requireValue) {
+      return const SizedBox.shrink();
+    }
+
+    final isDue = ref.watch(periodicReviewIsDueProvider);
+    final inbox = ref.watch(unfilteredInboxProvider);
+    final next = ref.watch(unfilteredNextActionsProvider);
+    final waiting = ref.watch(unfilteredWaitingForProvider);
+    final maybe = ref.watch(unfilteredMaybeProvider);
+    if (!isDue &&
+        !emptyActionableBannerTrigger(
+          inbox: inbox,
+          next: next,
+          waiting: waiting,
+          maybe: maybe,
+        )) {
+      return const SizedBox.shrink();
+    }
 
     return _BannerContent(
       key: const Key('periodic_review_banner_visible'),

--- a/app/lib/widgets/periodic_review_banner.dart
+++ b/app/lib/widgets/periodic_review_banner.dart
@@ -18,6 +18,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../providers/gtd_lists_provider.dart';
+import '../providers/onboarding_provider.dart';
 import '../providers/periodic_review_settings_provider.dart';
 
 class PeriodicReviewBanner extends ConsumerWidget {
@@ -42,8 +44,36 @@ class PeriodicReviewBanner extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    if (!ref.watch(periodicReviewBannerVisibleProvider)) {
+    if (!ref.watch(periodicReviewBannerEnabledProvider)) {
       return const SizedBox.shrink();
+    }
+    if (ref.watch(periodicReviewBannerDismissedTodayProvider)) {
+      return const SizedBox.shrink();
+    }
+
+    final hasTodos = ref.watch(hasTodosProvider);
+    if (!hasTodos.hasValue || !hasTodos.requireValue) {
+      return const SizedBox.shrink();
+    }
+
+    final isDue = ref.watch(periodicReviewIsDueProvider);
+    final inbox = ref.watch(unfilteredInboxProvider);
+    final next = ref.watch(unfilteredNextActionsProvider);
+    final waiting = ref.watch(unfilteredWaitingForProvider);
+    final maybe = ref.watch(unfilteredMaybeProvider);
+    if (!isDue) {
+      if (!inbox.hasValue ||
+          !next.hasValue ||
+          !waiting.hasValue ||
+          !maybe.hasValue) {
+        return const SizedBox.shrink();
+      }
+      final emptyActionableTrigger = inbox.requireValue.isEmpty &&
+          next.requireValue.isEmpty &&
+          (waiting.requireValue.isNotEmpty || maybe.requireValue.isNotEmpty);
+      if (!emptyActionableTrigger) {
+        return const SizedBox.shrink();
+      }
     }
 
     return _BannerContent(

--- a/app/lib/widgets/periodic_review_banner.dart
+++ b/app/lib/widgets/periodic_review_banner.dart
@@ -44,37 +44,23 @@ class PeriodicReviewBanner extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    if (!ref.watch(periodicReviewBannerEnabledProvider)) {
-      return const SizedBox.shrink();
-    }
-    if (ref.watch(periodicReviewBannerDismissedTodayProvider)) {
-      return const SizedBox.shrink();
-    }
-
-    final hasTodos = ref.watch(hasTodosProvider);
-    if (!hasTodos.hasValue || !hasTodos.requireValue) {
-      return const SizedBox.shrink();
-    }
-
-    final isDue = ref.watch(periodicReviewIsDueProvider);
-    final inbox = ref.watch(unfilteredInboxProvider);
-    final next = ref.watch(unfilteredNextActionsProvider);
-    final waiting = ref.watch(unfilteredWaitingForProvider);
-    final maybe = ref.watch(unfilteredMaybeProvider);
-    if (!isDue) {
-      if (!inbox.hasValue ||
-          !next.hasValue ||
-          !waiting.hasValue ||
-          !maybe.hasValue) {
-        return const SizedBox.shrink();
-      }
-      final emptyActionableTrigger = inbox.requireValue.isEmpty &&
-          next.requireValue.isEmpty &&
-          (waiting.requireValue.isNotEmpty || maybe.requireValue.isNotEmpty);
-      if (!emptyActionableTrigger) {
-        return const SizedBox.shrink();
-      }
-    }
+    // Inline `ref.watch` calls (not via periodicReviewBannerVisibleProvider)
+    // keep the widget's rebuild dependency graph exactly as its existing
+    // tests were calibrated for — routing the eight watches through a
+    // derived Provider<bool> measurably changes pump-to-emission timing
+    // and was breaking the tests. The predicate itself is deduped via
+    // computePeriodicReviewBannerVisible.
+    final visible = computePeriodicReviewBannerVisible(
+      enabled: ref.watch(periodicReviewBannerEnabledProvider),
+      dismissed: ref.watch(periodicReviewBannerDismissedTodayProvider),
+      hasTodos: ref.watch(hasTodosProvider),
+      isDue: ref.watch(periodicReviewIsDueProvider),
+      inbox: ref.watch(unfilteredInboxProvider),
+      next: ref.watch(unfilteredNextActionsProvider),
+      waiting: ref.watch(unfilteredWaitingForProvider),
+      maybe: ref.watch(unfilteredMaybeProvider),
+    );
+    if (!visible) return const SizedBox.shrink();
 
     return _BannerContent(
       key: const Key('periodic_review_banner_visible'),

--- a/app/lib/widgets/periodic_review_banner.dart
+++ b/app/lib/widgets/periodic_review_banner.dart
@@ -18,8 +18,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-import '../providers/gtd_lists_provider.dart';
-import '../providers/onboarding_provider.dart';
 import '../providers/periodic_review_settings_provider.dart';
 
 class PeriodicReviewBanner extends ConsumerWidget {
@@ -44,36 +42,8 @@ class PeriodicReviewBanner extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    if (!ref.watch(periodicReviewBannerEnabledProvider)) {
+    if (!ref.watch(periodicReviewBannerVisibleProvider)) {
       return const SizedBox.shrink();
-    }
-    if (ref.watch(periodicReviewBannerDismissedTodayProvider)) {
-      return const SizedBox.shrink();
-    }
-
-    final hasTodos = ref.watch(hasTodosProvider);
-    if (!hasTodos.hasValue || !hasTodos.requireValue) {
-      return const SizedBox.shrink();
-    }
-
-    final isDue = ref.watch(periodicReviewIsDueProvider);
-    final inbox = ref.watch(unfilteredInboxProvider);
-    final next = ref.watch(unfilteredNextActionsProvider);
-    final waiting = ref.watch(unfilteredWaitingForProvider);
-    final maybe = ref.watch(unfilteredMaybeProvider);
-    if (!isDue) {
-      if (!inbox.hasValue ||
-          !next.hasValue ||
-          !waiting.hasValue ||
-          !maybe.hasValue) {
-        return const SizedBox.shrink();
-      }
-      final emptyActionableTrigger = inbox.requireValue.isEmpty &&
-          next.requireValue.isEmpty &&
-          (waiting.requireValue.isNotEmpty || maybe.requireValue.isNotEmpty);
-      if (!emptyActionableTrigger) {
-        return const SizedBox.shrink();
-      }
     }
 
     return _BannerContent(

--- a/app/test/widgets/focus_session_planning_banner_test.dart
+++ b/app/test/widgets/focus_session_planning_banner_test.dart
@@ -7,6 +7,7 @@ import 'package:jeeves/providers/focus_session_planning_provider.dart';
 import 'package:jeeves/providers/focus_session_planning_settings_provider.dart';
 import 'package:jeeves/providers/gtd_lists_provider.dart';
 import 'package:jeeves/providers/onboarding_provider.dart';
+import 'package:jeeves/providers/periodic_review_settings_provider.dart';
 import 'package:jeeves/widgets/focus_session_planning_banner.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../test_helpers.dart';
@@ -67,6 +68,7 @@ Widget _buildBanner({
   required bool planningComplete,
   required bool bannerDismissed,
   required bool bannerEnabled,
+  bool weeklyReviewBannerVisible = false,
   Stream<bool>? hasTodosStream,
   Stream<List<Todo>>? inboxStream,
   Stream<List<Todo>>? nextStream,
@@ -110,6 +112,8 @@ Widget _buildBanner({
       focusSessionPlanningSettingsProvider.overrideWith(
           () => _MockFocusSessionPlanningSettingsNotifier(settings)),
       focusSessionPlanningProvider.overrideWith(() => mockPlanning),
+      periodicReviewBannerVisibleProvider
+          .overrideWith((_) => weeklyReviewBannerVisible),
       hasTodosProvider.overrideWith(
           (ref) => hasTodosStream ?? Stream.value(true)),
       unfilteredInboxProvider.overrideWith(
@@ -336,5 +340,40 @@ void main() {
     await tester.pump();
 
     expect(find.byKey(const Key('planning_banner_visible')), findsNothing);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Weekly review precedence
+  // ---------------------------------------------------------------------------
+
+  testWidgets('banner hidden when weekly review banner is visible',
+      (tester) async {
+    await _pumpBanner(
+      tester,
+      _buildBanner(
+        planningComplete: false,
+        bannerDismissed: false,
+        bannerEnabled: true,
+        weeklyReviewBannerVisible: true,
+      ),
+    );
+
+    expect(find.byKey(const Key('planning_banner_visible')), findsNothing);
+  });
+
+  testWidgets(
+      'banner visible when weekly review banner is not visible',
+      (tester) async {
+    await _pumpBanner(
+      tester,
+      _buildBanner(
+        planningComplete: false,
+        bannerDismissed: false,
+        bannerEnabled: true,
+        weeklyReviewBannerVisible: false,
+      ),
+    );
+
+    expect(find.byKey(const Key('planning_banner_visible')), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary

- The daily "Plan your day →" banner and the weekly "Start Weekly Review" banner were stacking when the weekly review was due and the user had items to plan today.
- `REQUIREMENTS.md` §Daily Planning Entry already specifies the weekly banner takes the slot — only the empty-actionable trigger was honouring that; the cadence-due case was not.
- Extract the weekly banner's visibility predicate into `periodicReviewBannerVisibleProvider` so `FocusSessionPlanningBanner` yields the slot by watching one provider. Re-evaluates automatically once the user dismisses the weekly banner or completes the review, returning the daily banner without a page reload.

## Test plan

- [x] `focus_session_planning_banner_test.dart`: new `banner hidden when weekly review banner is visible` and `banner visible when weekly review banner is not visible` cases.
- [x] All existing daily-banner test cases pass with `weeklyReviewBannerVisible` defaulted to `false`.
- [x] `periodic_review_banner_test.dart` exercises the new shared provider through its existing dependency overrides (no signature change for those tests).
- [ ] Manual smoke: set `periodic_review_last_completed_at` > 7 days ago with inbox items present → only the weekly banner shows; dismiss it → daily banner appears.

https://claude.ai/code/session_01JCTMRoaYfN5DHBuRZk9ahz

---
_Generated by [Claude Code](https://claude.ai/code/session_01JCTMRoaYfN5DHBuRZk9ahz)_