### PR TITLE
docs: introduce CONTEXT.md glossary, ADRs, and agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,13 +7,38 @@ Generic instructions for AI agents. Copy-pasteable to any project.
 1. **Check the scratchpad** (`SCRATCHPAD.md`) for current goal
 2. **Read project documentation:**
    - `README.md` - Project overview
+   - `CONTEXT.md` - Domain glossary across bounded contexts; authoritative for vocabulary
+   - `docs/adr/` - Architecture Decision Records; check before making architectural changes
    - `docs/REQUIREMENTS.md` - What we're building
    - `docs/ARCHITECTURE.md` - How it's built
    - `docs/TESTING.md` - Testing strategy (+ emulator tap coordinates for manual `adb` testing)
    - `docs/DESIGN.md` - Design system
 
-3. **Update Requirements:** Whenever the user asks for new requirements, update `docs/REQUIREMENTS.md` for future reference.
+3. **Update Requirements:** Whenever the user asks for new requirements, update `docs/REQUIREMENTS.md` for future reference. When new domain concepts arise, update `CONTEXT.md`. When you make a decision that meets the ADR three-criteria filter (see below), write an ADR.
 4. **Re-read specs every 30 minutes** or when uncertain. Requirements drift causes wasted work.
+
+## Domain Vocabulary (`CONTEXT.md`)
+
+`CONTEXT.md` is the source of truth for domain terms. It is organised into two top-level tiers (Conceptual / Implementation) with bounded contexts nested where they have grown large enough to warrant grouping.
+
+- **Use CONTEXT.md vocabulary verbatim** in code, docs, commit messages, PR descriptions, UI copy.
+- **Code and user-facing copy use the same terms.** Any divergence between code identifiers and UI labels needs a specific reason (cadence-flavour, established vernacular, accessibility) and an unambiguous mapping recorded in the relevant term's definition or Flagged ambiguities.
+- **New concepts the user thinks about** → add to the Conceptual tier first, then implement. The model can run ahead of the implementation; that is by design.
+- **Code conflicts with the conceptual model** → log under that context's Flagged ambiguities. Do not silently paper over a mismatch — the ambiguities list is the punch list for reconciliation work.
+- **CONTEXT.md describes the current conceptual state.** Treat it the same as `docs/`: not a changelog. Rewrite affected sections when the model changes; remove statements that are no longer true.
+
+## Architecture Decision Records (`docs/adr/`)
+
+ADRs preserve the reasoning behind decisions that future contributors would otherwise re-litigate blind.
+
+- **Before architectural changes:** scan `docs/adr/` for prior decisions that might apply or constrain. An ADR represents a deliberate choice, not a default.
+- **Write a new ADR** when a decision meets all three criteria:
+  1. Hard to reverse — the cost of changing your mind later is meaningful
+  2. Surprising without context — a future reader would wonder "why on earth did they do it this way?"
+  3. The result of a real trade-off — there were genuine alternatives picked for specific reasons
+- **Filename:** `docs/adr/NNNN-slug.md`, sequential numbering (scan the directory for the highest existing number and increment by one).
+- **Length:** typically 1–3 paragraphs. Record *that* a decision was made and *why* — not how to implement it. An ADR can be a single paragraph.
+- **ADRs are not changelogs.** If a later decision supersedes an earlier one, the earlier ADR stays in place and the newer one references it.
 
 ## Development Methodology: TDD (Top-Down)
 
@@ -65,6 +90,11 @@ Run full test suite before considering work complete.
 - **Always maintain data integrity**. Schema changes must not result in data loss for the user.
 - **Use proper migrations**. Write specific migration scripts to handle schema evolution.
 - **NEVER use destructive migrations**. Do not drop tables or perform operations which result in data loss. The user values their data.
+
+### Bounded Context Discipline
+- If `CONTEXT.md` defines bounded contexts, treat them as vocabulary boundaries — types and concepts from one context should not leak into another's function signatures or domain logic.
+- **Cross-context dependencies flow in the direction `CONTEXT.md` prescribes** — typically infrastructure or augmentation contexts depend on the core domain, never the reverse. A core-domain function signature referencing an infrastructure-context type is the warning sign.
+- When implementation lags the conceptual model (Conceptual-tier terms with no Implementation backing), the gap is recorded in Flagged ambiguities, not papered over with shortcut types.
 
 ## Versioning Policy (CRITICAL)
 
@@ -123,13 +153,15 @@ Update after completing each goal. Keep goals small (< 30 min each).
 | `AGENTS.md` | Agent instructions | Generic (copy to new projects) |
 | `SCRATCHPAD.md` | Current goals, working memory | Session-specific |
 | `README.md` | Project overview | Project-specific |
+| `CONTEXT.md` | Domain glossary across bounded contexts | Project-specific |
 | `docs/` | Detailed documentation | Project-specific |
+| `docs/adr/` | Architecture Decision Records | Project-specific |
 
-Keep AGENTS.md generic. Project details go in README.md and docs/.
+Keep AGENTS.md generic. Project details go in README.md, CONTEXT.md, and docs/.
 
 ## Documentation in docs/
 
-Files in docs/ (ARCHITECTURE.md, BACKEND_GUIDELINES.md, DESIGN.md, REQUIREMENTS.md, TESTING.md) describe the current state of the project. They are not changelogs. A reader should be able to understand the system today by reading them, without consulting git history, issues, or PRs.
+Files in docs/ (ARCHITECTURE.md, BACKEND_GUIDELINES.md, DESIGN.md, REQUIREMENTS.md, TESTING.md) and the root-level `CONTEXT.md` describe the current state of the project. They are not changelogs. A reader should be able to understand the system today by reading them, without consulting git history, issues, or PRs.
 When you change code that affects anything these documents describe, update the relevant document in the same change — not at the end of the session. Treat the docs as part of the code.
 When updating:
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-configure-file { "MD024": { "siblings_only": true } } -->
+
 # Jeeves
 
 Jeeves is an opinionated, offline-first, AI-augmented Getting Things Done (GTD) productivity app. This glossary defines the vocabulary of the system across its bounded contexts (GTD Core, Engagement, Ceremony Framework, Sync, AI Augmentation — codified as each is grilled).
@@ -124,11 +126,11 @@ The implicit List of Outcomes the user has deferred. Defined by: `Intent = maybe
 _Avoid_: Maybe, Later, Backlog
 
 **Done**:
-The implicit List of completed Outcomes. Defined by: `Completion is not null`.
+The implicit List of completed Outcomes the user still considers part of their record. Defined by: `Completion is not null` AND `Intent != trash`. A trashed-and-completed Outcome surfaces in **Trash**, not Done — the user's stance to discard takes precedence over the historical Completion fact, so the GTD lists remain pairwise disjoint.
 _Avoid_: Completed, Finished, Archive (Archive implies removal from active concerns; Done is just the achieved set)
 
 **Trash**:
-The implicit List of Outcomes the user has discarded. Defined by: `Intent = trash`. User-facing surface deferred.
+The implicit List of Outcomes the user has discarded. Defined by: `Intent = trash` (regardless of Completion). User-facing surface deferred.
 _Avoid_: Deleted, Removed (the row persists; Intent expresses the user's stance)
 
 #### Relationships
@@ -155,28 +157,28 @@ _Avoid_: Deleted, Removed (the row persists; Intent expresses the user's stance)
 
 > **Dev:** "If the user dictates 'remind me to call John' into the inbox, is that an Action?"
 > **Domain expert:** "It's a Capture. During clarification it becomes an Outcome — 'Catch up with John' — whose current Action is 'call John'. The Capture is the raw input; clarification produces the structure."
-
+>
 > **Dev:** "When the user finishes the current Action, is the Outcome automatically done?"
 > **Domain expert:** "Only if that Action was the last one needed. Otherwise the Outcome enters the no-current-Action state, and the user re-clarifies — possibly by promoting a planned Action."
-
+>
 > **Dev:** "If the user types three planned Actions during clarification but doesn't promote any, what's the Outcome's status?"
 > **Domain expert:** "It has three planned Actions and no current Action. The Outcome is on the radar but nothing is engageable yet. The user has externalised their thinking — the next clarification is where one gets promoted."
-
+>
 > **Dev:** "How can an Outcome have a Blocker *and* a current Action at the same time? Isn't a block the absence of a doable action?"
 > **Domain expert:** "No. The Blocker is on the Outcome — the outcome is waiting on Trixy. The current Action is 'follow up with Trixy' — something the user can do *while waiting*, that might even resolve the Blocker. Acting and waiting coexist."
-
+>
 > **Dev:** "If I move an Outcome to Someday/Maybe and then mark it done later, what was its Intent during the gap?"
 > **Domain expert:** "`maybe`. Intent is willingness — the user was willing to do it eventually. Completion is what happened. They're independent axes; the gap isn't a contradiction."
-
+>
 > **Dev:** "If the user finishes the current Action in a Focus session, does that stamp `last_clarified_at`?"
 > **Domain expert:** "No. Completion of an Action is engagement, not clarification. It's the *signal* that re-clarification is now needed — the Outcome flips to Stale — but the act of finishing isn't itself an act of thinking about the Outcome. The user has to come back and clarify what's next; that re-clarification is what stamps."
-
+>
 > **Dev:** "And declaring the *Outcome* itself done?"
 > **Domain expert:** "Stamps. Saying 'this is achieved' is a structural decision about the Outcome — a clarification act. Same for trashing."
-
+>
 > **Dev:** "If a user moves an Outcome from Next to Someday/Maybe, is the Outcome 'removed from' Next and 'added to' Someday/Maybe?"
 > **Domain expert:** "No — neither List has a membership column. Both are implicit Lists. The user changes the Outcome's Intent from `next` to `maybe`, and the Outcome's membership in both Lists changes as a consequence of the filter. The Lists are projections, not buckets — the model doesn't move the Outcome anywhere."
-
+>
 > **Dev:** "What about the Focus Session's task list? Is that the same kind of thing?"
 > **Domain expert:** "No — that's an explicit List. It has a stored membership (which Outcomes were selected for today). Both are Lists, but the explicit/implicit split matters for how mutation works: adding to Next means changing an Outcome's Intent; adding to a Focus Session's task list means writing a membership row."
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,362 @@
+# Jeeves
+
+Jeeves is an opinionated, offline-first, AI-augmented Getting Things Done (GTD) productivity app. This glossary defines the vocabulary of the system across its bounded contexts (GTD Core, Engagement, Ceremony Framework, Sync, AI Augmentation — codified as each is grilled).
+
+The glossary is organised into two top-level tiers:
+
+- **Conceptual** — the user's mental model. Concepts that would exist in a physical GTD system on paper, regardless of how (or whether) they are implemented. The user's world view is authoritative here.
+- **Implementation** — code-level abstractions that live in the code: storage shapes, UI/UX patterns, protocols. No physical-world counterpart from the user's perspective; the user sees Outcomes and Ceremonies, not Tags and Wizards. These names exist because the implementation needs them, not because the user thinks about them.
+
+Within each tier, terms are nested by bounded context only when the context's vocabulary has grown large enough that grouping helps navigation. Implementation often organises differently than concept — its splits follow storage and code-module boundaries, which need not mirror the conceptual contexts.
+
+**Term unification between model and user-facing copy.** Identifiers in code and labels in UI copy should use the same term wherever possible — divergence creates friction for both contributors (mental translation reading code) and users (mental translation reading docs). Any divergence requires:
+
+1. A specific reason — typically cadence-flavour (a generic state name rendered with the period's name in copy), GTD-vernacular preservation (a UI label that matches the user's known terminology), or accessibility.
+2. An unambiguous mapping documented in the relevant term's definition or Flagged ambiguities.
+
+The current known divergences:
+
+- **Next** (domain) is rendered as "Next Action" in UI copy when referring to the current-role Action of an Outcome on the Next List.
+- A FocusSession's **Plan** (domain) is rendered with cadence-flavoured copy ("Today's Plan" at the daily cadence).
+- A Nudge's `dismissed` / `completed` states (domain) are rendered with cadence-flavoured copy ("Not today" / "Not this week" / etc.) in Banner and Notification surfaces.
+
+Prospective renames considered and **deferred**, pending legacy cleanup:
+
+- **Action → Task** — currently rejected because "Task" is burned by inconsistent past usage (`task_id` columns referencing what we now call Outcome; architecture docs mixing "task" with "todo"). Reverting would re-conflate three concepts. Reconsider once the legacy is cleaned up and parity is achievable without re-conflating with retired meanings.
+- **Outcome → Project** — currently rejected because "Project" is the derived classification per ADR-0003 (an Outcome with multiple Actions), and Allen's canonical GTD definition would collide with single-Action items being called Projects. Reconsider only if the ADR-0003 distinction is itself revisited.
+
+## Conceptual
+
+### GTD Core
+
+#### Language
+
+**Capture**:
+A raw, unprocessed fragment the user has put into the system because it has their attention. Pending clarification; not yet an Outcome or Action.
+_Avoid_: Todo, Task, Item, Inbox item, Thought, Stuff, Note
+
+**Outcome**:
+A desired result the user is committed to achieving. The product of clarifying one or more Captures. An Outcome carries any number of Actions over its lifetime (current, planned, terminated).
+_Avoid_: Todo, Task, Goal
+
+**Project** *(derived classification)*:
+An Outcome that requires more than one Action over its lifetime — David Allen's GTD canonical "Project" (a multi-step outcome). Not a separate entity; derived from the existence of more than one Action against the Outcome. The system does not surface "Project" as a distinct type — the same Outcome shape carries both single-Action items and multi-Action projects.
+_Avoid_: Initiative, Umbrella, ProjectGroup (these would imply structural composition the model does not have)
+
+**Action**:
+A physical, visible activity that moves an Outcome forward. A first-class entity with its own identity and lifecycle, distinct from the Outcome it belongs to. An Action carries one of four roles at any time:
+
+- `planned` — captured as part of the user's externalised thinking about the Outcome, but not yet eligible to be acted on. Multiple `planned` Actions may exist for one Outcome.
+- `current` — the single Action eligible for engagement right now. Surfaced to the user as the GTD "Next Action."
+- `done` — completed by the user (stamps `done_at`).
+- `superseded` — replaced before completion (stamps `superseded_at`, optionally links to its replacement via `superseded_by_id`).
+
+Terminated Actions (`done` or `superseded`) stay attached to their Outcome — the chain of Actions over time is the Outcome's history.
+_Avoid_: Task (when referring to the action), Step, TodoStep, Subtask, Cursor, NextAction (provisional code name — see ambiguities)
+
+**Intent**:
+The user's *willingness* to pursue an Outcome. One of `next` (yes, soon), `maybe` (yes, eventually), or `trash` (no, never). Intent is a stance, not a fact about completion.
+_Avoid_: State, Status, Disposition (in this context)
+
+**Completion**:
+The fact that an Outcome has been achieved, recorded as a timestamp. Orthogonal to Intent — a user can change Intent on an unachieved Outcome without affecting Completion, and Completion happens to an Outcome regardless of Intent.
+_Avoid_: Done state, Done intent
+
+**Person**:
+A person the user knows, interacts with, or depends on. Identified by a user-chosen name. A first-class concept independent of any particular Blocker or Outcome — the same Person can be referenced from many Outcomes' PersonBlockers, and from Action text ("call Trixy") regardless of blocking state.
+_Avoid_: Contact, User (User is reserved for the app's owner), Collaborator
+
+**Area** *(of Focus)*:
+A domain of recurring responsibility — David Allen's GTD horizon-2 concept. Examples: "Health", "Finance", "Family", "Open-source maintenance." An Area is a permanent (or long-lived) categorisation; Outcomes belong to zero or more Areas.
+_Avoid_: Category, Topic, Project (Project is structural; Area is responsibility-domain)
+
+**Label**:
+A user-defined granular grouping. Jeeves-specific extension — not GTD canon — to let users categorise Outcomes more finely than Areas, or cut across Areas (e.g. "urgent-this-week" may span Health and Finance). Free-form; the user creates and retires Labels as needed.
+_Avoid_: Tag (Tag is the storage shape, not the concept), Bucket
+
+**Blocker**:
+Outside-the-user world-state relevant to an Outcome that is unresolved. Attaches to the Outcome (it describes the outcome's situation), and *coexists* with the Outcome's current Action — having a Blocker does not preclude having a current Action, and the current Action may be the very thing that resolves the Blocker.
+_Avoid_: Block, Dependency, Constraint (Constraint is reserved for action-level predicates — see Context)
+
+**PersonBlocker**:
+A Blocker whose unresolved world-state is "this Person has not yet acted." References a specific **Person**; existence of the reference is the wait, removal is its resolution. The user-visible list grouping Outcomes-by-Person is called **Waiting For**.
+_Avoid_: WaitingFor (as an entity name), Wait, PendingPerson
+
+**Context** *(deferred — not yet modelled)*:
+A predicate over current world state ("is *now* a moment when this action is doable?") that attaches to an Action and gates its visibility. Distinct from a Blocker: a Blocker describes outside-the-user state relevant to the *outcome*; a Context gates *whether you can act*. Examples: "@phone" (action is doable when phone is available), "after Nov 30" (action is doable from that date).
+_Avoid_: Constraint, Filter, Gate
+
+**Clarification**:
+The act of thinking about an Outcome (or a Capture in its first such act) and committing the result to the system. Manifests as a *stream of micro-acts* — each individual write that constitutes structural thinking-about-the-Outcome stamps `Outcome.last_clarified_at`. There is no "clarification session" entity; the UI may wrap micro-acts in a session-shaped flow but the domain commits each write independently. Distinct from **Engagement** (doing the current Action — does not stamp) and from **Organising** (sorting into structure via organising-type tags — does not stamp).
+_Avoid_: Review, Refresh, Process (Process is the GTD verb but overloaded with UI / queue / batch meanings)
+
+**Organising**:
+The act of placing an Outcome into the user's organisational structure — adding or removing **Area** memberships, **Label** assignments, or any future purely-categorisation linkages. Changes *where* an Outcome belongs without changing *what* it is or what's happening to it. The third sibling alongside **Clarification** (thinking about the Outcome — stamps `last_clarified_at`) and **Engagement** (doing the current Action — produces TimeLogs); Organising neither stamps nor logs. Note: PersonBlocker add/remove looks like Organising at the storage level (it's a Tag link) but is conceptually Clarification, since PersonBlocker is a Blocker on the Outcome, not a categorisation.
+_Avoid_: Categorising (narrower — covers only one mode of Organising), Filing, Tagging (Tag is the storage mechanism, not the act)
+
+**Stale** *(derived predicate)*:
+An Outcome whose `last_clarified_at < last_action_completion_at` — the current Action has terminated since the user last thought about the Outcome. The strongest "pick this up next clarification" signal.
+
+**Actionless** *(derived predicate)*:
+An Outcome with no current Action. May still have planned Actions (the user has externalised thinking but not committed to engagement) or none (planless).
+
+**Planless** *(derived predicate)*:
+An Outcome with no current Action **and** no planned Actions. The Outcome exists but the user has not externalised any "what's next." The strongest needs-attention signal among non-terminal Outcomes.
+
+**List**:
+A named collection of items. A List may be **explicit** — its membership is stored (e.g., the planned Actions of an Outcome, the task membership of a Focus Session) — or **implicit** — its membership is a derived query/filter applied to the system's entities (e.g., the GTD lists below, the Outcomes in an Area). The explicit/implicit split affects storage and ordering semantics but not the conceptual role. List exists as a first-class concept across every tier of the system: the model has explicit Lists as relations, the protocol serves Lists as collection endpoints, the UI renders every multi-item view as a List, the user *thinks* about their work in Lists. Anywhere a developer is tempted to invent a new "collection of X" abstraction, the question to ask first is *which kind of List is this?*
+_Avoid_: Collection, View, Bucket, Queue (Queue implies FIFO, which Lists do not require)
+
+**Inbox**:
+The implicit List of Captures pending clarification. The user's trusted bucket for unprocessed stuff.
+_Avoid_: Capture queue, Capture List
+
+**Next**:
+The implicit List of Outcomes the user has expressed willingness to handle next, without any Blocker preventing progress. Defined by: `Intent = next`, `Completion is null`, no PersonBlocker. The user engages with the row's *current Action* — but the List contains Outcomes, not Actions.
+_Avoid_: Next Actions (the list is of Outcomes, not Actions — though "Next Action" remains the user-facing label for the role of the row's current Action), Todo, Ready
+
+**Waiting For**:
+The implicit List of Outcomes that are PersonBlocked, grouped by the blocking Person. An Outcome blocked on multiple Persons appears under each Person it is blocked on. Disjoint from **Next** by construction (Next excludes PersonBlocked Outcomes), so the same Outcome never appears in both.
+_Avoid_: Waiting, Blocked, Pending
+
+**Someday/Maybe**:
+The implicit List of Outcomes the user has deferred. Defined by: `Intent = maybe`, `Completion is null`.
+_Avoid_: Maybe, Later, Backlog
+
+**Done**:
+The implicit List of completed Outcomes. Defined by: `Completion is not null`.
+_Avoid_: Completed, Finished, Archive (Archive implies removal from active concerns; Done is just the achieved set)
+
+**Trash**:
+The implicit List of Outcomes the user has discarded. Defined by: `Intent = trash`. User-facing surface deferred.
+_Avoid_: Deleted, Removed (the row persists; Intent expresses the user's stance)
+
+#### Relationships
+
+- A **Capture** is many-to-many with **Outcome**: one Capture may clarify to zero, one, or several Outcomes; one Outcome may trace back to several Captures (duplicate or complementary fragments merged during clarification).
+- An **Outcome** has at most one *current* **Action** at any time, may have any number of *planned* Actions (the user's externalised "what's next" thinking), and has 0..N *terminated* Actions (done or superseded) over its lifetime.
+- An **Outcome** that ends up needing multiple Actions is colloquially a *project* — no separate type is required.
+- An **Outcome** carries an **Intent** (the user's willingness) and may carry a **Completion** timestamp (the fact of achievement); the two axes are independent.
+- An **Outcome** may have any number of **Blockers** that *coexist* with its current **Action**. The classic case: a PersonBlocker "waiting on Trixy" lives on the Outcome while the current Action reads "follow up with Trixy." Acting on the current Action is what *might* resolve the Blocker; the two are not in opposition.
+- An **Action** belongs to exactly one **Outcome**. Captures reach Actions only indirectly, through the Outcomes they clarify to.
+- An **Outcome** is categorised into zero or more **Areas** (M:N) and labelled with zero or more **Labels** (M:N).
+- A **PersonBlocker** references exactly one **Person**; one Outcome may have multiple PersonBlockers (waiting on multiple Persons), and one Person may be the subject of PersonBlockers on multiple Outcomes.
+- A **Person** may also appear in Action text or Outcome notes without being a Blocker — referencing a Person does not imply blocking on them.
+- An **Action** may have zero or more **Contexts** (M:N) — deferred but conceptually committed; the relationship is owned by Action, not Outcome.
+- **Only the *current* Action is engageable.** Planned Actions cannot have TimeLogs, do not surface in **Next** / Focus Mode / Today's Plan. They are visible only in the context of their Outcome (where the Outcome's plan — an explicit List of planned Actions — is shown).
+- **Promotion from `planned` to `current` is an explicit clarifying act, never automatic.** When the current Action terminates, the Outcome enters the "no current Action" state until the user re-clarifies and either promotes a planned Action, edits one, or creates a new one.
+- **The plan carries no explicit dependencies.** Ordering among planned Actions is the user's intuition about sequence, not a DAG. The user revises ordering during clarification.
+- **TimeLog** records are attributed to an Action (not an Outcome) — you log time against the specific *action being performed*. An Outcome's total time invested is summed from the TimeLogs of its current and past Actions.
+- **Clarification stamps `last_clarified_at` per micro-act.** The principle: a write stamps iff it constitutes thinking-about-the-Outcome. Stamping writes include Outcome creation; title/notes/Intent/due-date edits; any Action mutation (create, edit, supersede, promote, demote, reorder, remove); Blocker add/remove (including PersonBlocker, however stored); explicit "still relevant" confirmation; Outcome completion or trashing. Non-stamping writes include current Action completion (engagement signal, not clarification), TimeLog writes, and Area / Label changes (organising).
+- **The three Freshness predicates compose freely.** An Outcome may be {Stale + has-current-Action}, {Actionless but with planned Actions}, {Planless and Stale}, etc. Different review surfaces emphasise different combinations — Daily Planning's re-clarify queue surfaces *Stale ∨ Actionless*; a future "abandoned Outcomes" surface might emphasise *Planless ∧ ¬Stale-but-old* (never thought about much, never planned). The predicates are the contract; the surfaces are downstream.
+- **The GTD lists (Inbox, Next, Waiting For, Someday/Maybe, Done, Trash) are pairwise disjoint by construction.** An Outcome is in at most one Outcome-bearing list at any time, and Inbox is over Captures so doesn't overlap with any of them. The disjointness is enforced by the filter definitions, not by an explicit "membership" column — they are implicit Lists.
+
+#### Example dialogue
+
+> **Dev:** "If the user dictates 'remind me to call John' into the inbox, is that an Action?"
+> **Domain expert:** "It's a Capture. During clarification it becomes an Outcome — 'Catch up with John' — whose current Action is 'call John'. The Capture is the raw input; clarification produces the structure."
+
+> **Dev:** "When the user finishes the current Action, is the Outcome automatically done?"
+> **Domain expert:** "Only if that Action was the last one needed. Otherwise the Outcome enters the no-current-Action state, and the user re-clarifies — possibly by promoting a planned Action."
+
+> **Dev:** "If the user types three planned Actions during clarification but doesn't promote any, what's the Outcome's status?"
+> **Domain expert:** "It has three planned Actions and no current Action. The Outcome is on the radar but nothing is engageable yet. The user has externalised their thinking — the next clarification is where one gets promoted."
+
+> **Dev:** "How can an Outcome have a Blocker *and* a current Action at the same time? Isn't a block the absence of a doable action?"
+> **Domain expert:** "No. The Blocker is on the Outcome — the outcome is waiting on Trixy. The current Action is 'follow up with Trixy' — something the user can do *while waiting*, that might even resolve the Blocker. Acting and waiting coexist."
+
+> **Dev:** "If I move an Outcome to Someday/Maybe and then mark it done later, what was its Intent during the gap?"
+> **Domain expert:** "`maybe`. Intent is willingness — the user was willing to do it eventually. Completion is what happened. They're independent axes; the gap isn't a contradiction."
+
+> **Dev:** "If the user finishes the current Action in a Focus session, does that stamp `last_clarified_at`?"
+> **Domain expert:** "No. Completion of an Action is engagement, not clarification. It's the *signal* that re-clarification is now needed — the Outcome flips to Stale — but the act of finishing isn't itself an act of thinking about the Outcome. The user has to come back and clarify what's next; that re-clarification is what stamps."
+
+> **Dev:** "And declaring the *Outcome* itself done?"
+> **Domain expert:** "Stamps. Saying 'this is achieved' is a structural decision about the Outcome — a clarification act. Same for trashing."
+
+> **Dev:** "If a user moves an Outcome from Next to Someday/Maybe, is the Outcome 'removed from' Next and 'added to' Someday/Maybe?"
+> **Domain expert:** "No — neither List has a membership column. Both are implicit Lists. The user changes the Outcome's Intent from `next` to `maybe`, and the Outcome's membership in both Lists changes as a consequence of the filter. The Lists are projections, not buckets — the model doesn't move the Outcome anywhere."
+
+> **Dev:** "What about the Focus Session's task list? Is that the same kind of thing?"
+> **Domain expert:** "No — that's an explicit List. It has a stored membership (which Outcomes were selected for today). Both are Lists, but the explicit/implicit split matters for how mutation works: adding to Next means changing an Outcome's Intent; adding to a Focus Session's task list means writing a membership row."
+
+#### Flagged ambiguities
+
+- The codebase currently conflates **Capture** and **Outcome** into a single `Todo` row (the `clarified` boolean axis distinguishes the two states). The conceptual model treats them as distinct entities with a many-to-many relationship between them.
+- The codebase stores **Action** data as cursor-fields on the Outcome row (`next_action_text`, `energy_level`, `time_estimate`, `time_spent_minutes`, `last_next_action_completion_at`) rather than as rows of a separate Actions table. The proposal at `docs/proposals/blockers-and-contexts.md` framed this as "NextAction is a lightweight cursor" — but that framing was the path of least resistance to ship Blockers, not a settled design decision. The conceptual gap (Action as a first-class entity with its own lifecycle, identity, and history) is real and remains open; implementation timing is a separate question.
+- The codebase has no representation of **planned** Actions today. The conceptual model treats the *plan* (an Outcome's ordered set of planned Actions) as a distinct thing the user externalises during clarification. Implementation may render this as a structured list of Action rows, as a free-text bullet list under Outcome notes, or as something an LLM parses at read time — all are valid implementations of the same concept.
+- **`clarified` (boolean)** on the current Todo row is an artifact of the Capture/Outcome conflation. Once Capture is split out, every Outcome is by construction clarified, and the boolean dissolves. **`last_clarified_at`** is a distinct concept — staleness of the *current* clarification — and survives the split.
+- The codebase uses "Todo" (DB table, Drift class) and "Task" (docs, foreign-key columns like `task_id`) for what the model calls an **Outcome**, and "NextAction" / `next_action_text` for what the model calls an **Action**. The proposal at `docs/proposals/blockers-and-contexts.md` uses "Task" and "NextAction" throughout; that document predates these renames.
+- The proposal's four long-term states (`active / someday / done / trashed`) collapse two independent axes (Intent and Completion) into one enum. The current code's `intent` column (`next / maybe / trash`) is the Intent axis; `done_at` is the Completion axis. The proposal's wording is the conceptual error; the code happens to be closer to right.
+- A trivially-actionable Capture (e.g. "call John") could in principle skip Outcome creation and land directly as an Action. The current model says no — every Capture clarifies through an Outcome, even a one-Action Outcome — to keep the path uniform. Open if a strong case emerges.
+- The `waiting_for` text column was added in migration v4 and dropped in migration v22. `docs/ARCHITECTURE.md:622,636-642` still describes it as a live column — stale. The current implementation uses `Tag(type='person')` linked through `TodoTags`. To be reconciled when the Architecture doc is rewritten.
+- The current code calls the **Next** List "Next Actions" throughout (provider names, screen names, UI copy). The List is conceptually a List of Outcomes — the action focus comes from each Outcome's current Action — so the plural-Actions name misleads. Renaming target: **Next** in code, providers, and copy; the role-label "Next Action" stays for the singular current Action of a row in that List.
+
+### Engagement
+
+#### Language
+
+**FocusSession**:
+A user session comprising three phases — **Planning**, **Execution**, and **Review** — during which the user engages with a curated subset of Outcomes. Calendar-independent: the same workflow applies whether multiple FocusSessions occur in a day or a single FocusSession spans multiple days. The UI currently surfaces FocusSession's lifecycle at a daily cadence through the planning and review Ceremonies (see Ceremony Framework context — TBD), but cadence is a UI choice, not a domain constraint. At most one FocusSession is open per user at any time.
+
+The three phases:
+
+- **Planning** — the user opens a FocusSession and curates its **Plan**: an explicit List of Outcomes scoped to this session. Surfaced today by the `focus_session_planning` Ceremony ("Daily Planning" at the daily cadence).
+- **Execution** — the body of the session. The user engages with one Outcome on the Plan at a time via its current Action; the **Focus** (below) identifies which. TimeLogs accumulate against the focused Outcome's current Action.
+- **Review** — the user closes the FocusSession, assigning a **Disposition** to every non-completed Outcome (from the Plan or off-Plan engagement). Surfaced today by the `focus_session_review` Ceremony ("Evening Shutdown" at the daily cadence).
+
+The **Plan** is a property of the FocusSession, not a stand-alone entity — it has no existence or meaning outside the session it scopes. A user-facing UI may render the Plan with cadence-flavoured copy ("Today's Plan" at the daily cadence), but the domain concept is just "the FocusSession's Plan."
+
+The **Focus** is the property on FocusSession identifying which Outcome on the Plan is currently being engaged with. Like Plan, it has no existence outside the session. The Focus is set when the user starts engaging with a chosen Outcome from the Plan; it may be null (no Outcome focused — e.g. a freshly-opened session, the gap between Outcomes, or a session whose Outcomes have all completed). User-facing copy may say "in progress" or "active task"; the domain name is Focus.
+
+A sibling concept, **PeriodicSession**, will be added when the Weekly Review surface is grilled — it is a separate entity, not a parameterisation of FocusSession (per proposal §6.1, #185).
+_Avoid_: Engagement Session, Work Session, Day Session, Daily Session (all imply a cadence FocusSession is deliberately decoupled from)
+
+**Engagement**:
+The act of doing the current Action of an Outcome — manifests as TimeLog accumulation against that Action. The third sibling alongside **Clarification** and **Organising**. Does not stamp `last_clarified_at` (Engagement is the *signal* that re-clarification may be due, not the act of clarifying).
+
+Engagement is **independent of FocusSession**: the user may engage ad hoc with any Outcome from any List, at any time, with or without an open FocusSession. The FocusSession is the *recommended* discipline — its Planning and Review phases create a curated environment for engagement — but the presence (or absence) of a session does not gate the act of doing.
+_Avoid_: Doing, Execution (Execution is FocusSession's middle phase, not the verb), Work
+
+**TimeLog**:
+A record of one continuous interval of engagement with a specific Action. Each TimeLog carries:
+
+- A reference to the engaged Action (required)
+- A start time (required)
+- An end time (null while open / in-progress; set when the engagement ends)
+- Optional attribution to the open FocusSession at start time (null for ad-hoc engagement)
+
+Invariants:
+
+- At most one TimeLog is open per user at any moment — Engagement is sequential.
+- **There is no "pause" concept.** A TimeLog runs continuously from start to stop. The user either keeps engaging or stops (closing the TimeLog); resuming later opens a new TimeLog.
+- During Pomodoro, sprint→break and break→sprint transitions do **not** close the TimeLog. Breaks are part of engagement — the clock keeps running through them.
+
+Switching Actions closes the current TimeLog and opens a new one against the new Action.
+_Avoid_: Activity, Interval, WorkLog, Session (overloaded), Pause / Resume (these vocabulary items were removed in #246 / PR #252 — see ambiguities)
+
+**Sprint** / **Break**:
+Subdivisions of a TimeLog applying the Pomodoro discipline. A **Sprint** is a timed work block; a **Break** is the rest block between Sprints. The clock keeps running through both — Sprints and Breaks subdivide the TimeLog's rhythm without breaking its continuity. Purely a UI overlay and discipline aid — **not persisted as entities, not tracked in the model**. The only structural contact Pomodoro has with the rest of the system is the UI's pre-computed Sprint count for an Action, derived from `Action.time_estimate / Sprint duration` — and even that is presentational rather than required.
+_Avoid_: PomodoroPhase, FocusBlock, WorkBlock
+
+**Disposition**:
+The user's decision in the Review phase for an Outcome that did not complete during the FocusSession. One of three values:
+
+- `rollover` — pre-select this Outcome for the next FocusSession's Planning (user can deselect there).
+- `leave` — return to its normal List membership; no special handling.
+- `maybe` — set Intent to `maybe`, moving the Outcome to Someday/Maybe.
+
+A Disposition is recorded per-(FocusSession, Outcome) pair — it is a property of the relationship between the session and the Outcome, not of either standalone. Applied to every non-completed Outcome surfaced in Review (the union of Plan members and off-Plan engaged Outcomes). Completed Outcomes need no Disposition.
+_Avoid_: Resolution, Decision, Handling, Action (overloaded)
+
+#### Relationships
+
+- The **Plan** is a *commitment* set captured during the Planning phase; it does not auto-mutate during Execution. Off-Plan engagement is allowed and attributes to the session, but does not modify the Plan. The Plan-vs-actually-engaged gap is preserved as information — useful for retrospection, coaching, and future AI augmentation.
+- **Focus** may point to any Outcome the user is engaging with, whether or not that Outcome is on the Plan.
+- A **TimeLog** writes attribute to the open FocusSession (if one exists at engagement time) regardless of whether the engaged Outcome is on the Plan. If no FocusSession is open, the TimeLog is ad hoc — no session attribution.
+- The **Review** phase surfaces every Outcome that was either on the Plan or engaged with during the session (the union), so neither off-Plan work nor planned-but-untouched Outcomes slip past disposition.
+- **An Action may have many TimeLogs** over its lifetime — different engagement intervals on the same Action, possibly across multiple FocusSessions, possibly interspersed with engagement on other Actions within the same FocusSession. An Outcome's TimeLogs are the union of its Actions' TimeLogs.
+- **The hierarchy is FocusSession → TimeLog → (Sprint+Break cycles).** A FocusSession is "from when the user sits down at the table to when they get up" and contains multiple TimeLogs (one per engagement interval). Each TimeLog is subdivided into Pomodoro Sprint+Break cycles at the user's chosen cadence as a UI rhythm; the cycles do not persist or break the TimeLog's continuity.
+
+#### Flagged ambiguities
+
+- "Plan" is polymorphic in Jeeves' vocabulary. The **FocusSession's Plan** (this context) is a List of *Outcomes* selected for one session. An **Outcome's plan** (GTD Core) is its List of *planned Actions* — the user's externalised "what's next" thinking for a single Outcome. Different scopes, same English word; context disambiguates. If the clash bites in code or copy, the per-Outcome notion can be rewritten as "the planned Actions of an Outcome" without losing meaning; the per-session notion is the one that needs the short name.
+- **There is no "pause" in the engagement model.** An earlier implementation surfaced a pause control which was actually an unlabelled "start break" — corrected in #246 / PR #252 (commits a95c7ab, 2efab56, bfc6d66). Residual `pause` / `isPaused` / `resume` references may persist in code, copy, or older docs; treat any such reference as a candidate for removal. The two real intents the misnomer collapsed: *abandon sprint* (Stop) and *take a break* (Start break — a phase transition, not a clock suspension).
+
+### Ceremony Framework
+
+#### Language
+
+**Ceremony**:
+A guided activity the user performs with the app's facilitation. The app surfaces structure, prompts, and sequencing; the user provides the decisions and judgments. A Ceremony is a core domain concept — *what* the user is doing — independent of *how* the app surfaces it. May be implemented as a Wizard (the most common form), but other shapes are possible (single modal, inline form, voice flow, etc.). The current set: `focus_session_planning`, `focus_session_review`, `periodic_review`, and the in-flight inbox-clarification flow (when it splits from session planning per #184).
+_Avoid_: Ritual (narrower — see below), Wizard (an implementation form, see Implementation tier), Flow
+
+**Ritual**:
+A Ceremony that the app treats as integral to the user's practice — strongly suggested, regularly nudged for, expected to recur. The "Daily Planning Ritual" is a Ritual because the app considers it core to Jeeves' opinionated GTD discipline. An ad-hoc clarification of a one-off Capture is just a Ceremony, not a Ritual. The Ritual designation adds *discipline overlay* (recommended cadence, Nudge surfacing, completion tracking) on top of the underlying Ceremony — not a separate kind of activity.
+_Avoid_: Habit, Practice, Routine (none carry the "integral to the app's discipline" connotation precisely)
+
+**Nudge**:
+The app's mechanism for suggesting a Ritual to the user — a contextual reminder that the disciplined Ceremony is due. Belongs only to Rituals (not all Ceremonies); ad-hoc Ceremonies are user-initiated and need no Nudge.
+
+A Nudge has state across its lifecycle:
+
+- *visible* — the Ritual is due (per Cadence or other trigger) and not yet completed in the current period.
+- *dismissed* — user dismissed the Nudge for the current period ("not this time"); suppressed until the period turns.
+- *snoozed* — user deferred to a specific later time within the current period; the Nudge re-surfaces when that time arrives.
+- *completed* — the Ritual happened in the current period; the Nudge is suppressed until the period turns.
+
+A Ritual has at most one active Nudge at a time. The Nudge's *surfaces* — how the user actually sees it — are Implementation: see **Banner** and **Notification** in the Implementation tier.
+_Avoid_: Reminder (a separate concept — see ambiguities), Prompt, Suggestion (overloaded with AI surfaces)
+
+**Cadence**:
+The recurring schedule that determines when a Ritual is due — daily, weekly, or longer-period. Drives the *visible* transition of the Ritual's Nudge: when the period turns and the Ritual hasn't been completed in the new period, the Nudge becomes visible. Resets the Nudge's *completed* and *dismissed* states at period boundaries.
+
+Belongs only to Rituals; ad-hoc Ceremonies have no Cadence (they happen when the user chooses). Current Rituals carry hardcoded Cadences: Daily Planning (daily), Evening Shutdown (daily), Weekly Review (every 7 days). Future cadences may be user-configurable.
+_Avoid_: Schedule (overloaded — implies fixed times of day), Frequency (less precise), Period (too generic), Rhythm (informal)
+
+#### Relationships
+
+- A **Ritual** is a **Ceremony** combined with a **Cadence** and a **Nudge**. Removing the Cadence + Nudge demotes a Ritual to a plain Ceremony; adding them to a Ceremony promotes it.
+- A **Nudge** has zero or more *surfaces* (currently **Banner** and **Notification**) that deliver it to the user. The conceptual state of the Nudge is independent of which surfaces are wired up; changing or adding surfaces does not change what a Nudge *is*.
+- **Cadence** drives the Nudge's *visible* transition and the period-boundary reset of *completed* and *dismissed*; a Nudge without a Cadence (not currently a real configuration) would need an alternative trigger.
+- A **Ceremony** may be implemented as a **Wizard** (current default for all three Rituals) or any other UI form. The implementation form is independent of the Ceremony concept.
+- **Disposition** (defined in Engagement) is the per-Outcome decision used inside FocusSession's Review-type Ceremonies (Evening Shutdown). Other Ceremonies — notably the forthcoming PeriodicSession review — may introduce their own decision vocabularies.
+
+#### Flagged ambiguities
+
+- **Nudge** (this context) and **Reminder** (forthcoming, GTD Core) are different concepts. A Nudge targets a *Ritual* — the app suggesting "it's time for your weekly review." A Reminder targets an *individual Action* — "remind me to call John at 5pm." Different scopes, different triggers, different lifecycles. Do not collapse them into a single primitive even though both involve OS notifications under the hood.
+- **Banner and Notification machinery is currently duplicated per Ritual** (one set of state and code for Daily Planning, another for Evening Shutdown, another for Weekly Review). The Nudge abstraction is the consolidation target — a single Nudge-aware Banner and a single Nudge-aware Notification scheduler, parametrised by Ritual, replacing the three bespoke implementations.
+
+### Sync
+
+Sync is responsible for bidirectional offline-first replication between the Flutter app's local SQLite store and the PostgreSQL backend. Most of its vocabulary is technical and lives in the Implementation tier; the user does not think in sync vocabulary — they expect data to follow them across devices and the app to work without connectivity, without naming the mechanisms that achieve either. What belongs in this section is the Relationships subsection — the architectural discipline that keeps Sync from leaking upward into the contexts above it.
+
+#### Relationships
+
+- **Sync types do not appear in GTD Core / Engagement / Ceremony Framework function signatures.** The dependency direction is strictly one-way: those three contexts speak Drift/in-memory entities; Sync mechanically replicates those entities to PostgreSQL without adding semantics. Any change that would add a Sync-tier type (Bucket, Sync Token, BackendConnector reference) to a method signature in another context is the warning sign.
+- **Sync is additive — the app's offline behaviour does not depend on a working Sync layer.** If the BackendConnector fails to reach the backend, local writes queue and the user continues to work; replication resumes when connectivity returns. Conversely, if Sync is configured off entirely, the app remains fully functional as a single-device GTD store.
+- **Each context owns what is replicated.** GTD Core decides Outcomes, Actions, Tags, etc. are replicated; Engagement decides FocusSessions and TimeLogs are; Ceremony Framework has nothing structural to replicate today. Sync mechanically follows those choices but does not influence them.
+- **Local-only state is not replicated by design.** Sprint timer state in SharedPreferences, ephemeral UI focus, and per-device preferences (when added) stay local. Each context's Implementation tier specifies what is local-only versus replicated.
+- **Conflict resolution is Last-Write-Wins (LWW) in v1.** Acceptable for the current single-user-many-devices model; collaboration features (when they land) may require operation-based or CRDT-style resolution on the shapes they touch.
+
+## Implementation
+
+**Tag** *(backs the GTD Core concepts Person, Area, Label, and legacy Context)*:
+The shared storage row backing several conceptual entities, discriminated by a `Tag.type` field. Outcome ↔ Tag links are stored in a `TodoTags` join table; the join carries no role information of its own (its semantics depend entirely on the linked Tag's `type`). The user does not think in terms of Tags — they think in terms of the domain entities Tag backs. Physical-world equivalent: a folder, sticky note, or label-maker — a categorisation mechanism, not a domain concept. Each conceptual entity Tag currently backs has its own Conceptual-tier glossary entry; this entry exists so the code's `tags` table has a name in this glossary without implying that "Tag" is part of the user's mental model.
+_Avoid_: (none — Tag is the canonical name for the storage)
+
+**Banner** *(an in-app surface for a Nudge)*:
+A persistent visual element rendered at the top of shell-hosted screens, suggesting a Ritual to the user when its Nudge is *visible*. Dismissible (sets the Nudge to *dismissed* for the current period) and tappable (opens the underlying Ceremony). User-facing dismissal copy is cadence-flavoured ("Not today" at daily cadence, "Not this week" at weekly), but the underlying state transition is the same. Today each Ritual has its own bespoke Banner implementation — a target for consolidation under a single Nudge-driven Banner abstraction.
+_Avoid_: Toast (transient), Snackbar (transient), Alert (overloaded)
+
+**Notification** *(an OS-level surface for a Nudge)*:
+A platform-delivered alert (Android / iOS / web push) that surfaces a Nudge even when the app is not in the foreground. Carries the same actions as the in-app Banner: open (opens the Ceremony), snooze (sets the Nudge to *snoozed* with a deferred time within the current period), skip (sets the Nudge to *dismissed* for the current period). User-facing skip copy is cadence-flavoured ("Skip today" at daily cadence, "Skip this week" at weekly). Today each Ritual schedules its own Notification — same consolidation target as Banner.
+_Avoid_: Push, Alert, Reminder (Reminder is a separate concept — see ambiguities)
+
+**PowerSync** *(the current Sync engine)*:
+The replication engine used by Jeeves — a self-hosted `journeyapps/powersync-service` instance providing bidirectional sync between the Flutter SQLite store and the PostgreSQL backend. PowerSync uses Postgres for its internal bucket storage; no separate sync database is required. The engine is replaceable in principle — Sync's discipline rule (Sync types don't leak into other contexts) is what protects the rest of the app from a hypothetical engine swap.
+_Avoid_: (none — PowerSync is the canonical name for the current engine)
+
+**Sync Shape** *(one of the seven replicated data subsets)*:
+The schema definition of a subset of model data that replicates per user — specifies which rows belong in the user's replication stream and how they are filtered. The current seven Sync Shapes: `todos`, `tags`, `todo_tags`, `time_logs`, `focus_sessions`, `focus_session_tasks`, `user_preferences`. Six are filtered by `user_id` directly; `focus_session_tasks` joins through `focus_sessions` since it carries no `user_id` of its own.
+_Avoid_: Sync rule (PowerSync's internal term), Replication shape, Sync schema
+
+**Bucket** *(the runtime replication unit)*:
+A single user's instance of a Sync Shape — the actual replication stream materialised by PowerSync. One Bucket exists per `(user, Sync Shape)` pair. The user never sees a Bucket; the term exists for code and operational debugging.
+_Avoid_: Sync stream (vaguer), Channel (overloaded), Shard
+
+**BackendConnector** *(the local-to-backend upload path)*:
+The interface (currently `JevesBackendConnector` in code) that PowerSync uses to upload local writes to the Jeeves backend's REST API. Local writes are queued by PowerSync and replayed through this connector when connectivity is available. The Sync engine reads from the backend's PostgreSQL directly; only writes flow through the connector.
+_Avoid_: Sync connector (acceptable but BackendConnector is the canonical class name), Upload pipe
+
+**Sync Token**:
+The short-lived JWT issued by the backend's `GET /powersync/credentials` endpoint and consumed by PowerSync for authentication. The backend signs it with `SECRET_KEY`; PowerSync validates with the same key. Distinct from the user's auth tokens (access / refresh JWTs from the auth provider), though the v1 implementation shares the signing key.
+_Avoid_: PowerSync token (acceptable colloquially but Sync Token is the canonical name), Sync credential, JWT (too generic)
+
+**Last-Write-Wins (LWW)** *(the v1 conflict resolution policy)*:
+The conflict resolution rule for replicated data: when concurrent edits from multiple devices target the same row, the edit with the latest `updated_at` timestamp wins. Acceptable for the current single-user-many-devices model; future collaboration features may require operation-based or CRDT-style resolution on the shapes they touch. Applied implicitly by PowerSync via the `updated_at` column — not a separate code surface.
+_Avoid_: Last-write-wins (capitalisation drift), Latest wins, Newest wins
+
+**Wizard** *(one possible implementation form for a Ceremony)*:
+A UI/UX pattern for guiding a user through a structured multi-step input flow. Carries the affordances expected of the pattern: next / back / skip controls, a progress indicator, a status line, and optionally intra-step progress for compound steps. A Wizard is composed of **Steps** — bounded sub-activities sequenced linearly, each with its own subject matter and UI surface. A Step may auto-skip when its prerequisite is empty (e.g. an empty Inbox skips the Inbox-clarification Step). The current code implements every Ceremony (Daily Planning, Evening Shutdown, Weekly Review) as a Wizard, but the Wizard form — and the Step concept along with it — is part of the *implementation*, not part of the Ceremony being implemented. A non-Wizard surfacing of a Ceremony (a single modal, an inline form, a voice flow) would not have Steps.
+_Avoid_: Stepper, Carousel, MultiStep, Flow (Flow is used colloquially but is broader)

--- a/docs/adr/0001-action-as-first-class-entity.md
+++ b/docs/adr/0001-action-as-first-class-entity.md
@@ -1,0 +1,7 @@
+# Action as a first-class entity
+
+Proposal `docs/proposals/blockers-and-contexts.md` §6 / [#185](https://github.com/TMaYaD/Jeeves/issues/185) framed "NextAction" as a lightweight cursor — a text field on the Outcome plus supporting metadata, no separate entity, no lifecycle, no history. That framing was the path-of-least-resistance to ship Blockers without re-opening the entity question; it was a sidestep, not a settled design.
+
+We are reversing it. Action is a first-class entity with identity, a four-role lifecycle (`planned` / `current` / `done` / `superseded`), supersession as a row (not in-place edits), and TimeLog attribution at the Action grain.
+
+The cursor model collapsed fields that conceptually belong to *the action of doing* (energy, time estimate, time spent, waiting-for) onto the Outcome row, eroding the outcome-vs-action distinction the rest of the model now depends on. Promoting Action preserves per-action metadata, keeps the chain of past Actions as the Outcome's history for retrospection and AI augmentation, and lets TimeLog attach where engagement actually happens.

--- a/docs/adr/0002-plan-as-commitment-not-auto-growing.md
+++ b/docs/adr/0002-plan-as-commitment-not-auto-growing.md
@@ -1,0 +1,7 @@
+# Plan as commitment, not auto-growing
+
+A FocusSession's Plan is the List of Outcomes selected during Planning. When the user engages off-Plan during the session, the Plan can either stay fixed (commitment) or auto-grow to include the engaged Outcome. Both shapes are coherent and the Review surface ends up identical either way — the difference is only in what "Plan" means.
+
+We chose **commitment**: Plan stays fixed at Planning. Off-Plan engagement is allowed (per ADR-0005) and attributes to the session, but does not modify the Plan. The Plan-vs-actually-engaged set is preserved as two distinct pieces of information.
+
+Planning is a deliberate act — auto-mutating the Plan blurs the line between deliberate selection and ad-hoc engagement. The plan-vs-reality gap is a useful retrospective signal ("I keep planning things I don't do," "I keep getting pulled into off-plan work") that auto-growing destroys at the source. The commitment model is also strictly more information-preserving: the auto-growing view can be derived from the commitment model's data (Plan ∪ engaged), but the original-intent set cannot be recovered from the auto-growing model without an audit trail.

--- a/docs/adr/0003-no-multi-outcome-project-composition.md
+++ b/docs/adr/0003-no-multi-outcome-project-composition.md
@@ -1,0 +1,7 @@
+# No multi-Outcome Project composition
+
+A "Project" colloquially means a multi-step goal. There are two ways to model it: (a) an Outcome that requires multiple Actions over its lifetime, (b) an Outcome with child Outcomes forming a parent-child tree. Tools like OmniFocus and Things support shape (b).
+
+We use shape (a) only. Project is a derived classification — an Outcome that ends up needing more than one Action — not a separate entity, not a parent of other Outcomes. There is no parent-child Outcome relationship.
+
+Multi-Outcome composition introduces tree semantics (cascade-on-trash, completion propagation, nested permissions, ordered/unordered children) without a concrete use case driving them. The Action lifecycle already carries multi-step Outcomes coherently. Cross-Outcome grouping at higher horizons is served by Areas (recurring responsibility domains) and Labels (granular categorisation), not by Outcome composition. If a concrete need for tree semantics emerges later, adding a parent-child relationship is forward-compatible; the present cost of avoiding it is zero.

--- a/docs/adr/0004-single-current-action-with-planned-queue.md
+++ b/docs/adr/0004-single-current-action-with-planned-queue.md
@@ -1,0 +1,7 @@
+# Single current Action with optional planned queue, no auto-promotion
+
+An Outcome's engageable-now Actions can be modelled three ways: 0..1 (sequential-only, GTD purist), 0..N (parallel projects, OmniFocus-style with a `mode` flag), or 0..1-current plus N planned with explicit promotion (queued thinking).
+
+We chose the third: 0..1 current Action per Outcome plus a planned queue. Promotion from `planned` to `current` is an explicit clarifying act — never automatic. Planned Actions are not engageable (no TimeLogs, do not surface in Next / Focus Mode / a FocusSession's Plan); they are visible only in the Outcome's own detail view.
+
+Single current preserves the GTD discipline that "what is THE next physical thing?" forces clarity. The planned queue gets future-action thinking out of the user's head — meeting GTD's "don't leave thoughts in the head" goal — without inviting waterfall planning, dependency graphs (DAGs), or queue-tetris. No auto-promotion keeps each transition a deliberate clarification act, not procedure: when the current Action terminates, the Outcome enters the no-current-Action state until the user explicitly re-clarifies. 0..1 → 0..N is strictly forward-compatible if lived experience ever justifies parallel-project semantics; the reverse would require destructive schema changes.

--- a/docs/adr/0005-engagement-independent-of-focussession.md
+++ b/docs/adr/0005-engagement-independent-of-focussession.md
@@ -1,0 +1,7 @@
+# Engagement independent of FocusSession
+
+FocusSession is the recommended discipline — Planning → Execution → Review wraps engagement in a curated environment. The act of engagement itself (doing the current Action, logging time) could either require an open FocusSession (gating) or happen ad hoc with or without one (additive).
+
+Engagement is independent of FocusSession. The user may engage with any Outcome from any List at any time; if a FocusSession is open at engagement time, the TimeLog attributes to it (and to off-Plan engagement, per ADR-0002); if no FocusSession is open, the TimeLog is ad hoc with a null session FK.
+
+The FocusSession's purpose is to *create* an environment for engagement, not to *impose* it. Gating engagement on a session bypasses GTD's canonical model (ad-hoc Next Action picking by context, energy, and time is the normal mode), creates attribution edge cases (orphan engagement vs degenerate auto-created sessions), and conflates the discipline overlay with the underlying act. The cost of supporting ad-hoc engagement is a nullable session FK on TimeLog — trivial. The benefit is that the system's discipline does not impede the doing.

--- a/docs/adr/0006-capture-distinct-from-outcome.md
+++ b/docs/adr/0006-capture-distinct-from-outcome.md
@@ -1,0 +1,7 @@
+# Capture distinct from Outcome
+
+The current schema conflates two states into one `Todo` row via a `clarified` boolean: unclarified inbox items (`clarified=false`) and clarified Outcomes (`clarified=true`). The conceptual model treats them as distinct entities.
+
+Capture and Outcome are separate concepts in the model. A **Capture** is a raw, unprocessed fragment the user has put into the system because it has their attention — pending clarification, not yet an Outcome. An **Outcome** is the product of clarifying one or more Captures. The relationship between them is many-to-many: multiple Captures may merge into one Outcome during clarification; one Capture may spawn multiple Outcomes. Implementation timing is a separate concern — the conceptual split holds regardless of when the schema is refactored.
+
+Forcing capture to fit the Outcome shape (must have a title, must have an Intent, must eventually have an Action) puts the cart before the horse. Many GTD captures are reference material, duplicates, or fragments that get merged or discarded during clarification; the conflation under `clarified=false` loses that semantics. The M:N relationship preserves it: a busy week of fragmentary thoughts can clarify into a coherent set of Outcomes without losing the trail of how the user got there, and an Outcome's clarification history is itself useful information for retrospection and AI augmentation.

--- a/docs/adr/0007-breaks-count-as-engagement-time.md
+++ b/docs/adr/0007-breaks-count-as-engagement-time.md
@@ -1,0 +1,9 @@
+# Breaks count as engagement time
+
+The TimeLog runs continuously from when the user starts engaging with an Action to when they stop. Pomodoro Sprint↔Break transitions do not close it. As a consequence, **Break time is counted in the Outcome's total time-spent** — there is no per-row distinction between "active" Sprint clock and "rest" Break clock.
+
+Many productivity tools take the opposite stance — Breaks are deducted, "time spent" reflects only the Sprint clock. We considered and rejected that model.
+
+A Break is not a gap in engagement — it is part of the engagement rhythm. Mid-Sprint distractions are abandonment (Stop), not Breaks; a Break is a deliberate choice in service of the next Sprint. Excluding Break time would force the model to distinguish "real" engagement from "support" engagement, a brittle split that invites edge cases (does a stretching break count? a snack run? a bathroom break? a Slack reply?). Counting all clock time spent in the engagement loop keeps the boundary clean: TimeLog measures wall-clock engagement, period.
+
+This decision also follows directly from the no-pause invariant ([#246](https://github.com/TMaYaD/Jeeves/issues/246), PR [#252](https://github.com/TMaYaD/Jeeves/pull/252)): once we ruled out a clock-suspension state, the only consistent treatment of Breaks is to count them. A reader of the schema who sees `time_logs` rows spanning Pomodoro cycles without internal subdivision is looking at this decision in effect.


### PR DESCRIPTION
## Summary

Introduces a domain glossary, captures architectural decisions, and updates agent instructions to make both load-bearing for future work.

- **`CONTEXT.md`** — domain glossary across the five bounded contexts (GTD Core, Engagement, Ceremony Framework, Sync, AI Augmentation). Organised into Conceptual and Implementation tiers; codifies the term-unification principle between code and copy with the known divergences catalogued; records Flagged ambiguities where the current implementation diverges from the conceptual model, forming a punch list for future reconciliation. The model deliberately runs ahead of the implementation in several places — notably Capture/Outcome split, Action as a first-class entity, planned Actions, Plan-as-commitment, and the Nudge consolidation target.
- **`docs/adr/`** — seven ADRs preserving the reasoning behind decisions that meet the hard-to-reverse + surprising-without-context + real-trade-off filter:
  - `0001` Action as a first-class entity (supersedes the cursor framing of proposal §6 / #185)
  - `0002` Plan as commitment, not auto-growing
  - `0003` No multi-Outcome Project composition
  - `0004` Single current Action with optional planned queue, no auto-promotion
  - `0005` Engagement independent of FocusSession
  - `0006` Capture distinct from Outcome
  - `0007` Breaks count as engagement time (follows from #246 / PR #252's no-pause invariant)
- **`AGENTS.md`** — adds top-level sections on Domain Vocabulary and Architecture Decision Records, plus Bounded Context Discipline under Code Principles. Teaches future agents to treat CONTEXT.md as authoritative for vocabulary, to check `docs/adr/` before architectural changes, and to write ADRs when decisions meet the three-criteria filter.

## Test plan

- [ ] `CONTEXT.md` reads coherently end-to-end; each context's Language → Relationships → Example dialogue → Flagged ambiguities flow is internally consistent.
- [ ] ADRs cross-reference correctly (e.g. 0002 ↔ 0005 on Plan attribution, 0001 ↔ 0004 on Action lifecycle, 0007 ↔ #246).
- [ ] `AGENTS.md`'s new guidance is followable — a fresh agent reading it would know to consult CONTEXT.md before coding and to check / write ADRs at the right moments.
- [ ] No code changes; no test suite impact. Verification is by review.