### PR TITLE
chore: gitignore .claude/worktrees harness state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 SCRATCHPAD.md
+.claude/worktrees/


### PR DESCRIPTION
## Summary

Adds `.claude/worktrees/` to `.gitignore`. This directory holds transient subagent worktrees managed by the Claude Code harness — it should never appear as untracked in `git status`, and the project's stop-hook flags it when it does.

## Test plan
- [x] `git status` is clean while subagent worktrees exist under `.claude/worktrees/`
- [x] Tracked `.claude/settings.json` and `.claude/scheduled_tasks.lock` are unaffected (only `worktrees/` is ignored, not the whole `.claude/`)

https://claude.ai/code/session_01TGgeQyXqCwaeJEXQgsPAxE

---
_Generated by [Claude Code](https://claude.ai/code/session_01TGgeQyXqCwaeJEXQgsPAxE)_